### PR TITLE
Enable compilation on GHC 8.10 and accept newer version of `dhall`

### DIFF
--- a/lib/mobility-core/package.yaml
+++ b/lib/mobility-core/package.yaml
@@ -100,7 +100,7 @@ dependencies:
   - unordered-containers
   - geojson
   - safe-money
-  - dhall
+  - dhall <= 1.35.0
   - tasty
   - tasty-hunit
   - either

--- a/lib/mobility-core/package.yaml
+++ b/lib/mobility-core/package.yaml
@@ -118,7 +118,7 @@ dependencies:
   - monad-logger
   - unliftio-core
   - resource-pool
-  - universum
+  - universum < 1.8
   - scientific
   - vector
   - unliftio

--- a/lib/mobility-core/src/Kernel/External/Maps/Interface/Google.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Interface/Google.hs
@@ -56,7 +56,7 @@ getDistancesWrapper ::
   Maybe GoogleMaps.Mode ->
   Bool ->
   m [GetDistanceResp a b]
-getDistancesWrapper GetDistancesReq {..} limitedOriginObjectsList limitedDestinationObjectsList googleMapsUrl key mode isAvoidTolls = concatForM limitedOriginObjectsList $ \limitedOriginObjects ->
+getDistancesWrapper _ limitedOriginObjectsList limitedDestinationObjectsList googleMapsUrl key mode isAvoidTolls = concatForM limitedOriginObjectsList $ \limitedOriginObjects ->
   concatForM limitedDestinationObjectsList $ \limitedDestinationObjects ->
     do
       let limitedOriginPlaces = map (latLongToPlace . getCoordinates) limitedOriginObjects

--- a/lib/mobility-core/src/Kernel/Mock/Utils.hs
+++ b/lib/mobility-core/src/Kernel/Mock/Utils.hs
@@ -20,7 +20,7 @@ import qualified Data.Aeson.Types as Ae
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import Data.Either.Extra
-import Data.List
+import qualified Data.List as List
 import Data.String.Conversions
 import qualified Data.Text as T
 import Data.Time
@@ -64,6 +64,6 @@ decodeEitherJSON bs = do
   first T.pack $ Ae.parseEither parseJSON val
 
 findAndDecode :: (FromJSON a) => BS.ByteString -> [(BS.ByteString, BS.ByteString)] -> Either Text a
-findAndDecode key list = maybeToEither errMsg (lookup key list) >>= decodeEitherJSON
+findAndDecode key list = maybeToEither errMsg (List.lookup key list) >>= decodeEitherJSON
   where
     errMsg = "failed to find key: " <> cs key

--- a/lib/mobility-core/src/Kernel/Storage/Esqueleto/Queries.hs
+++ b/lib/mobility-core/src/Kernel/Storage/Esqueleto/Queries.hs
@@ -75,7 +75,6 @@ import Database.Esqueleto.Experimental as EsqExport hiding
   )
 import qualified Database.Esqueleto.Experimental as Esq
 import qualified Database.Esqueleto.Internal.Internal as Esq
-import Database.Persist.Postgresql hiding (delete, repsert, update, upsert, upsertBy)
 import Kernel.Prelude
 import Kernel.Storage.Esqueleto.Class
 import Kernel.Storage.Esqueleto.DTypeBuilder

--- a/lib/mobility-core/src/Kernel/Utils/Dhall.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Dhall.hs
@@ -54,8 +54,11 @@ readDhallConfigDefault appname = do
 instance {-# OVERLAPS #-} Num a => FromDhall a where
   autoWith inn = fmap fromInteger (autoWith inn :: Decoder Integer)
 
+#if MIN_VERSION_dhall(1, 35, 0)
+#else
 instance FromDhall Word16 where
   autoWith inn = fmap fromIntegral (autoWith inn :: Decoder Natural)
+#endif
 
 deriving instance FromDhall Scheme
 


### PR DESCRIPTION
This change is necessary for using this package in the nixpkgs `ghc8107` package set, which is how we plan to Nixify the whole of nammayatri backend (see https://github.com/nammayatri/nammayatri/issues/9).