### PR TITLE
backend/feat: #106 make idfy as interface

### DIFF
--- a/lib/mobility-core/mobility-core.cabal
+++ b/lib/mobility-core/mobility-core.cabal
@@ -72,6 +72,20 @@ library
       Kernel.External.SMS.MyValueFirst.Types
       Kernel.External.SMS.Types
       Kernel.External.Types
+      Kernel.External.Verification
+      Kernel.External.Verification.Idfy.Auth
+      Kernel.External.Verification.Idfy.Client
+      Kernel.External.Verification.Idfy.Config
+      Kernel.External.Verification.Idfy.Flow
+      Kernel.External.Verification.Idfy.Types
+      Kernel.External.Verification.Idfy.Types.Error
+      Kernel.External.Verification.Idfy.Types.Request
+      Kernel.External.Verification.Idfy.Types.Response
+      Kernel.External.Verification.Idfy.WebhookHandler
+      Kernel.External.Verification.Interface
+      Kernel.External.Verification.Interface.Idfy
+      Kernel.External.Verification.Interface.Types
+      Kernel.External.Verification.Types
       Kernel.External.Whatsapp.GupShup.Config
       Kernel.External.Whatsapp.GupShup.Flow
       Kernel.External.Whatsapp.Interface

--- a/lib/mobility-core/src/Kernel/External/Verification.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification.hs
@@ -11,22 +11,7 @@
 
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE TemplateHaskell #-}
 
-module Kernel.External.Whatsapp.Types
-  ( module Kernel.External.Whatsapp.Types,
-  )
-where
+module Kernel.External.Verification (module Reexport) where
 
-import Data.OpenApi
-import EulerHS.Prelude
-import Kernel.Storage.Esqueleto (derivePersistField)
-
-data WhatsappService = GupShup
-  deriving (Show, Read, Eq, Ord, Generic, ToJSON, FromJSON, ToSchema)
-
-availableWhatsappServices :: [WhatsappService]
-availableWhatsappServices = [GupShup]
-
-derivePersistField "WhatsappService"
+import Kernel.External.Verification.Interface as Reexport

--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/Auth.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/Auth.hs
@@ -1,0 +1,48 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.Verification.Idfy.Auth where
+
+import qualified Data.Map.Strict as Map
+import EulerHS.Prelude
+import Kernel.External.Encryption
+import Kernel.External.Verification.Idfy.Config
+import Kernel.Tools.Metrics.CoreMetrics.Types
+import Kernel.Types.Error
+import Kernel.Utils.Common
+import Kernel.Utils.IOLogging
+import Network.HTTP.Client as Http
+import Network.HTTP.Client.TLS as Http
+
+verifyAuth ::
+  ( EncFlow m r,
+    HasField "isShuttingDown" r (TMVar ()),
+    HasField "coreMetrics" r CoreMetricsContainer,
+    HasField "loggerEnv" r LoggerEnv,
+    Log m
+  ) =>
+  IdfyCfg ->
+  Maybe Text ->
+  m ()
+verifyAuth cfg authSecret = do
+  cfgSecret <- decrypt cfg.secret
+  unless (authSecret == Just cfgSecret) $ throwError (InvalidRequest "INVALID_AUTHORIZATION_HEADER")
+
+prepareIdfyHttpManager :: Int -> Map String Http.ManagerSettings
+prepareIdfyHttpManager timeout =
+  Map.singleton idfyHttpManagerKey $
+    Http.tlsManagerSettings {Http.managerResponseTimeout = Http.responseTimeoutMicro (timeout * 1000)}
+
+idfyHttpManagerKey :: String
+idfyHttpManagerKey = "idfy-http-manager"

--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/Client.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/Client.hs
@@ -1,0 +1,211 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.Verification.Idfy.Client
+  ( verifyDLAsync,
+    verifyRCAsync,
+    validateImage,
+    extractRCImage,
+    extractDLImage,
+    getTask,
+    VerifyDLAPI,
+    VerifyRCAPI,
+    ValidateImage,
+    ExtractDLImage,
+    ExtractRCAPI,
+  )
+where
+
+import EulerHS.Prelude
+import qualified EulerHS.Types as T
+import Kernel.External.Verification.Idfy.Auth
+import Kernel.External.Verification.Idfy.Config
+import Kernel.External.Verification.Idfy.Types.Error
+import Kernel.External.Verification.Idfy.Types.Request
+import Kernel.External.Verification.Idfy.Types.Response
+import Kernel.Tools.Metrics.CoreMetrics.Types
+import Kernel.Types.Common
+import Kernel.Utils.Common hiding (Error)
+import Servant (Get, Header, JSON, Post, ReqBody, (:>))
+
+type VerifyDLAPI =
+  "v3" :> "tasks" :> "async" :> "verify_with_source" :> "ind_driving_license"
+    :> Header "api-key" ApiKey
+    :> Header "account-id" AccountId
+    :> ReqBody '[JSON] DLVerificationRequest
+    :> Post '[JSON] IdfySuccess
+
+verifyDLAPI :: Proxy VerifyDLAPI
+verifyDLAPI = Proxy
+
+verifyDLAsync ::
+  ( MonadFlow m,
+    CoreMetrics m
+  ) =>
+  ApiKey ->
+  AccountId ->
+  BaseUrl ->
+  DLVerificationRequest ->
+  m IdfySuccess
+verifyDLAsync apiKey accountId url req = callIdfyAPI url task "verifyDLAsync"
+  where
+    task =
+      T.client
+        verifyDLAPI
+        (Just apiKey)
+        (Just accountId)
+        req
+
+type VerifyRCAPI =
+  "v3" :> "tasks" :> "async" :> "verify_with_source" :> "ind_rc_plus"
+    :> Header "api-key" ApiKey
+    :> Header "account-id" AccountId
+    :> ReqBody '[JSON] RCVerificationRequest
+    :> Post '[JSON] IdfySuccess
+
+verifyRCAPI :: Proxy VerifyRCAPI
+verifyRCAPI = Proxy
+
+verifyRCAsync ::
+  ( MonadFlow m,
+    CoreMetrics m
+  ) =>
+  ApiKey ->
+  AccountId ->
+  BaseUrl ->
+  RCVerificationRequest ->
+  m IdfySuccess
+verifyRCAsync apiKey accountId url req = callIdfyAPI url task "verifyRCAsync"
+  where
+    task =
+      T.client
+        verifyRCAPI
+        (Just apiKey)
+        (Just accountId)
+        req
+
+type ValidateImage =
+  "v3" :> "tasks" :> "sync" :> "validate" :> "document"
+    :> Header "api-key" ApiKey
+    :> Header "account-id" AccountId
+    :> ReqBody '[JSON] ImageValidateRequest
+    :> Post '[JSON] ImageValidateResponse
+
+validateImageAPI :: Proxy ValidateImage
+validateImageAPI = Proxy
+
+validateImage ::
+  ( MonadFlow m,
+    CoreMetrics m
+  ) =>
+  ApiKey ->
+  AccountId ->
+  BaseUrl ->
+  ImageValidateRequest ->
+  m ImageValidateResponse
+validateImage apiKey accountId url req = callIdfyAPI url task "validateImage"
+  where
+    task =
+      T.client
+        validateImageAPI
+        (Just apiKey)
+        (Just accountId)
+        req
+
+type ExtractRCAPI =
+  "v3" :> "tasks" :> "sync" :> "extract" :> "ind_rc"
+    :> Header "api-key" ApiKey
+    :> Header "account-id" AccountId
+    :> ReqBody '[JSON] ImageExtractRequest
+    :> Post '[JSON] RCExtractResponse
+
+extractRCAPI :: Proxy ExtractRCAPI
+extractRCAPI = Proxy
+
+extractRCImage ::
+  ( MonadFlow m,
+    CoreMetrics m
+  ) =>
+  ApiKey ->
+  AccountId ->
+  BaseUrl ->
+  ImageExtractRequest ->
+  m RCExtractResponse
+extractRCImage apiKey accountId url req = callIdfyAPI url task "extractRCImage"
+  where
+    task =
+      T.client
+        extractRCAPI
+        (Just apiKey)
+        (Just accountId)
+        req
+
+type ExtractDLImage =
+  "v3" :> "tasks" :> "sync" :> "extract" :> "ind_driving_license"
+    :> Header "api-key" ApiKey
+    :> Header "account-id" AccountId
+    :> ReqBody '[JSON] ImageExtractRequest
+    :> Post '[JSON] DLExtractResponse
+
+extractDLAPI :: Proxy ExtractDLImage
+extractDLAPI = Proxy
+
+extractDLImage ::
+  ( MonadFlow m,
+    CoreMetrics m
+  ) =>
+  ApiKey ->
+  AccountId ->
+  BaseUrl ->
+  ImageExtractRequest ->
+  m DLExtractResponse
+extractDLImage apiKey accountId url req = callIdfyAPI url task "extractDLImage"
+  where
+    task =
+      T.client
+        extractDLAPI
+        (Just apiKey)
+        (Just accountId)
+        req
+
+type GetTaskAPI =
+  "v3" :> "tasks"
+    :> Header "api-key" ApiKey
+    :> Header "account-id" AccountId
+    :> MandatoryQueryParam "request_id" Text
+    :> Get '[JSON] VerificationResponse
+
+getTaskApi :: Proxy GetTaskAPI
+getTaskApi = Proxy
+
+getTask ::
+  ( MonadFlow m,
+    CoreMetrics m
+  ) =>
+  ApiKey ->
+  AccountId ->
+  BaseUrl ->
+  Text ->
+  m VerificationResponse
+getTask apiKey accountId url request_id = callIdfyAPI url task "getTask"
+  where
+    task =
+      T.client
+        getTaskApi
+        (Just apiKey)
+        (Just accountId)
+        request_id
+
+callIdfyAPI :: CallAPI env res
+callIdfyAPI = callApiUnwrappingApiError (identity @IdfyError) (Just idfyHttpManagerKey) (Just "IDFY_ERROR")

--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/Config.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/Config.hs
@@ -11,22 +11,22 @@
 
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DerivingStrategies #-}
 
-module Kernel.External.Whatsapp.Types
-  ( module Kernel.External.Whatsapp.Types,
-  )
-where
+module Kernel.External.Verification.Idfy.Config where
 
-import Data.OpenApi
-import EulerHS.Prelude
-import Kernel.Storage.Esqueleto (derivePersistField)
+import Kernel.External.Encryption
+import Kernel.Prelude
 
-data WhatsappService = GupShup
-  deriving (Show, Read, Eq, Ord, Generic, ToJSON, FromJSON, ToSchema)
+data IdfyCfg = IdfyCfg
+  { accountId :: EncryptedField 'AsEncrypted AccountId,
+    apiKey :: EncryptedField 'AsEncrypted ApiKey,
+    secret :: EncryptedField 'AsEncrypted Text,
+    url :: BaseUrl
+  }
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (FromJSON, ToJSON)
 
-availableWhatsappServices :: [WhatsappService]
-availableWhatsappServices = [GupShup]
+type AccountId = Text
 
-derivePersistField "WhatsappService"
+type ApiKey = Text

--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/Flow.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/Flow.hs
@@ -1,0 +1,29 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.Verification.Idfy.Flow
+  ( IdfyWebhookAPI,
+  )
+where
+
+import EulerHS.Prelude
+import Kernel.Types.Common
+import Kernel.Utils.Common hiding (Error)
+import Servant hiding (throwError)
+
+type IdfyWebhookAPI =
+  "service" :> "idfy" :> "verification"
+    :> Header "Authorization" Text
+    :> ReqBody '[JSON] Value
+    :> Post '[JSON] AckResponse

--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/Types.hs
@@ -1,0 +1,8 @@
+module Kernel.External.Verification.Idfy.Types
+  ( module Reexport,
+  )
+where
+
+import Kernel.External.Verification.Idfy.Types.Error as Reexport
+import Kernel.External.Verification.Idfy.Types.Request as Reexport
+import Kernel.External.Verification.Idfy.Types.Response as Reexport

--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/Types/Error.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/Types/Error.hs
@@ -1,0 +1,92 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Kernel.External.Verification.Idfy.Types.Error where
+
+import Kernel.Types.Error.BaseError
+import Kernel.Types.Error.BaseError.HTTPError
+import Kernel.Types.Error.BaseError.HTTPError.FromResponse (FromResponse (fromResponse))
+import Network.HTTP.Types (Status (statusCode))
+import Servant.Client (ResponseF (responseStatusCode))
+import Prelude
+
+data IdfyError
+  = IdfyNotConfigured
+  | IdfyBadRequest
+  | IdfyInvalidCredentials
+  | IdfyMissingCredentials
+  | IdfyNotFound
+  | IdfySizeLimitExceed
+  | IdfyUnprocessableEntity
+  | IdfyRateLimitExceed
+  | IdfyInternalServer
+  | IdfyBadGateway
+  deriving (Eq, Show, IsBecknAPIError)
+
+instanceExceptionWithParent 'HTTPException ''IdfyError
+
+instance FromResponse IdfyError where
+  fromResponse resp = case statusCode $ responseStatusCode resp of
+    400 -> Just IdfyBadRequest
+    401 -> Just IdfyMissingCredentials
+    403 -> Just IdfyInvalidCredentials
+    404 -> Just IdfyNotFound
+    413 -> Just IdfySizeLimitExceed
+    422 -> Just IdfyUnprocessableEntity
+    429 -> Just IdfyRateLimitExceed
+    500 -> Just IdfyInternalServer
+    502 -> Just IdfyBadGateway
+    _ -> Just IdfyInternalServer
+
+instance IsBaseError IdfyError where
+  toMessage = \case
+    IdfyNotConfigured -> Just "Idfy env variables aren't properly set."
+    IdfyBadRequest -> Just "Bad request. Please check for the input."
+    IdfyInvalidCredentials -> Just "Something went wrong on our end. Please try again."
+    IdfyMissingCredentials -> Just "Something went wrong on our end. Please try again."
+    IdfyNotFound -> Just "Something went wrong on our end. Please try again."
+    IdfySizeLimitExceed -> Just "Image size is more than 2MB. Please check for the size."
+    IdfyUnprocessableEntity -> Just "Unprocessable image. Please check for the image."
+    IdfyRateLimitExceed -> Just "Something went wrong on our end. Please try again."
+    IdfyInternalServer -> Just "Something went wrong on our end. Please try again."
+    IdfyBadGateway -> Just "Something went wrong on our end. Please try again."
+
+instance IsHTTPError IdfyError where
+  toErrorCode = \case
+    IdfyNotConfigured -> "IDFY_NOT_CONFIGURED"
+    IdfyBadRequest -> "BAD_REQUEST"
+    IdfyInvalidCredentials -> "INTERNAL_SERVER_ERROR"
+    IdfyMissingCredentials -> "INTERNAL_SERVER_ERROR"
+    IdfyNotFound -> "INTERNAL_SERVER_ERROR"
+    IdfySizeLimitExceed -> "SIZE_LIMIT_EXCEED"
+    IdfyUnprocessableEntity -> "UNPROCESSABLE_ENTITY"
+    IdfyRateLimitExceed -> "INTERNAL_SERVER_ERROR"
+    IdfyInternalServer -> "INTERNAL_SERVER_ERROR"
+    IdfyBadGateway -> "INTERNAL_SERVER_ERROR"
+
+  toHttpCode = \case
+    IdfyNotConfigured -> E500
+    IdfyBadRequest -> E400
+    IdfyInvalidCredentials -> E500
+    IdfyMissingCredentials -> E500
+    IdfyNotFound -> E500
+    IdfySizeLimitExceed -> E400
+    IdfyUnprocessableEntity -> E400
+    IdfyRateLimitExceed -> E500
+    IdfyInternalServer -> E500
+    IdfyBadGateway -> E500
+
+instance IsAPIError IdfyError

--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/Types/Request.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/Types/Request.hs
@@ -1,0 +1,74 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module Kernel.External.Verification.Idfy.Types.Request where
+
+import Data.OpenApi
+  ( ToSchema (..),
+    fromAesonOptions,
+    genericDeclareNamedSchema,
+  )
+import EulerHS.Prelude
+import Kernel.Utils.JSON (stripPrefixUnderscoreIfAny)
+
+type ImageValidateRequest = IdfyRequest ValidateRequest
+
+type ImageExtractRequest = IdfyRequest ExtractRequest
+
+type DLVerificationRequest = IdfyRequest DLVerificationData
+
+type RCVerificationRequest = IdfyRequest RCVerificationData
+
+data IdfyRequest a = IdfyRequest
+  { task_id :: Text,
+    group_id :: Text,
+    _data :: a
+  }
+  deriving (Show, Generic)
+
+instance (ToSchema a) => ToSchema (IdfyRequest a) where
+  declareNamedSchema = genericDeclareNamedSchema $ fromAesonOptions stripPrefixUnderscoreIfAny
+
+instance (FromJSON a) => FromJSON (IdfyRequest a) where
+  parseJSON = genericParseJSON stripPrefixUnderscoreIfAny
+
+instance (ToJSON a) => ToJSON (IdfyRequest a) where
+  toJSON = genericToJSON stripPrefixUnderscoreIfAny
+
+-- validate image request
+data ValidateRequest = ValidateRequest
+  { document1 :: Text,
+    doc_type :: Text
+  }
+  deriving (Show, Generic, ToJSON, FromJSON, ToSchema)
+
+-- extract image request
+data ExtractRequest = ExtractRequest
+  { document1 :: Text,
+    document2 :: Maybe Text
+  }
+  deriving (Show, Generic, ToJSON, FromJSON, ToSchema)
+
+-- DL verification request
+data DLVerificationData = DLVerificationData
+  { id_number :: Text,
+    date_of_birth :: Text
+  }
+  deriving (Show, Generic, ToJSON, FromJSON, ToSchema)
+
+-- RC verification request
+data RCVerificationData = RCVerificationData
+  {rc_number :: Text, _a :: Maybe Text}
+  deriving (Show, Generic, ToJSON, FromJSON, ToSchema)

--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/Types/Response.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/Types/Response.hs
@@ -1,0 +1,293 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module Kernel.External.Verification.Idfy.Types.Response where
+
+import Data.Aeson hiding (Error)
+import Data.OpenApi hiding (name)
+import EulerHS.Prelude hiding (state)
+import Kernel.Utils.JSON
+import Kernel.Utils.Time
+
+type ImageValidateResponse = IdfyResponse ValidateResponse
+
+type RCExtractResponse = IdfyResponse (ExtractionOutput RCExtractionOutput)
+
+type DLExtractResponse = IdfyResponse (ExtractionOutput DLExtractionOutput)
+
+type VerificationResponse = IdfyResponse IdfyResult
+
+type VerificationResponseList = [IdfyResponse IdfyResult]
+
+type IdfyResult = Output DLVerificationOutput RCVerificationOutput
+
+data IdfyResponse a = IdfyResponse
+  { action :: Text,
+    completed_at :: UTCTime,
+    created_at :: UTCTime,
+    group_id :: Text,
+    request_id :: Text,
+    result :: Maybe a,
+    status :: Text,
+    task_id :: Text,
+    _type :: Text
+  }
+  deriving (Show, Generic)
+
+instance (ToSchema a) => ToSchema (IdfyResponse a) where
+  declareNamedSchema = genericDeclareNamedSchema $ fromAesonOptions stripPrefixUnderscoreIfAny
+
+instance (FromJSON a) => FromJSON (IdfyResponse a) where
+  parseJSON = genericParseJSON stripPrefixUnderscoreIfAny
+
+instance (ToJSON a) => ToJSON (IdfyResponse a) where
+  toJSON = genericToJSON stripPrefixUnderscoreIfAny
+
+data IdfySuccess = IdfySuccess {request_id :: Text, _a :: Maybe Text}
+  deriving (Show, Generic, ToJSON, FromJSON, ToSchema)
+
+-- RC Result
+newtype ExtractionOutput a = ExtractionOutput {extraction_output :: a}
+  deriving (Show, Generic)
+
+instance (ToSchema a) => ToSchema (ExtractionOutput a)
+
+instance (ToJSON a) => ToJSON (ExtractionOutput a)
+
+instance (FromJSON a) => FromJSON (ExtractionOutput a)
+
+-- DL Result
+newtype SourceOutput a = SourceOutput {source_output :: a}
+  deriving (Show, Generic)
+
+instance (ToSchema a) => ToSchema (SourceOutput a)
+
+instance (ToJSON a) => ToJSON (SourceOutput a)
+
+instance (FromJSON a) => FromJSON (SourceOutput a)
+
+data Output a b = Output {source_output :: Maybe a, extraction_output :: Maybe b}
+  deriving (Show, Generic, ToJSON, FromJSON, ToSchema)
+
+-- RC verification response
+data RCVerificationOutput = RCVerificationOutput
+  { avg_gross_vehicle_weight :: Maybe Text,
+    axle_configuration :: Maybe Text,
+    chassis_number :: Maybe Text,
+    emission_norms :: Maybe Text,
+    color :: Maybe Text,
+    colour :: Maybe Text,
+    engine_number :: Maybe Text,
+    fitness_upto :: Maybe Text,
+    fuel_type :: Maybe Text,
+    insurance_details :: Maybe Text,
+    insurance_validity :: Maybe Text,
+    manufacturer :: Maybe Text,
+    mv_tax_upto :: Maybe Text,
+    owner_name :: Maybe Text,
+    permit_type :: Maybe Text,
+    permit_validity_upto :: Maybe Text,
+    permit_issue_date :: Maybe Text,
+    permit_number :: Maybe Text,
+    puc_validity_upto :: Maybe Text,
+    registration_date :: Maybe Text,
+    registration_number :: Maybe Text,
+    rto_name :: Maybe Text,
+    status :: Maybe Text,
+    vehicle_class :: Maybe Text,
+    vehicle_financier :: Maybe Text,
+    noc_valid_upto :: Maybe Text,
+    seating_capacity :: Maybe Text,
+    variant :: Maybe Text,
+    npermit_upto :: Maybe Text,
+    manufacturer_model :: Maybe Text,
+    standing_capacity :: Maybe Text,
+    status_message :: Maybe Text,
+    number_of_cylinder :: Maybe Text,
+    colour :: Maybe Text,
+    puc_valid_upto :: Maybe Text,
+    permanent_address :: Maybe Text,
+    permit_no :: Maybe Text,
+    father_name :: Maybe Text,
+    status_verfy_date :: Maybe Text,
+    m_y_manufacturing :: Maybe Text,
+    gross_vehicle_weight :: Maybe Text,
+    registered_place :: Maybe Text,
+    insurance_policy_no :: Maybe Text,
+    noc_details :: Maybe Text,
+    npermit_issued_by :: Maybe Text,
+    sleeper_capacity :: Maybe Text,
+    current_address :: Maybe Text,
+    status_verification :: Maybe Text,
+    permit_validity_from :: Maybe Text,
+    puc_number :: Maybe Text,
+    owner_mobile_no :: Maybe Text,
+    blacklist_status :: Maybe Text,
+    body_type :: Maybe Text,
+    unladden_weight :: Maybe Text,
+    insurance_name :: Maybe Text,
+    owner_serial_number :: Maybe Text,
+    vehicle_category :: Maybe Text,
+    npermit_no :: Maybe Text,
+    cubic_capacity :: Maybe Text,
+    norms_type :: Maybe Text,
+    financer :: Maybe Text,
+    wheelbase :: Maybe Text
+  }
+  deriving (Show, Generic, ToJSON, FromJSON, ToSchema)
+
+-- DL Verification response
+data DLVerificationOutput = DLVerificationOutput
+  { address :: Maybe Text,
+    badge_details :: Maybe Text,
+    card_serial_no :: Maybe Text,
+    city :: Maybe Text,
+    date_of_issue :: Maybe Text,
+    date_of_last_transaction :: Maybe Text,
+    dl_status :: Maybe Text,
+    dob :: Maybe Text,
+    face_image :: Maybe Text,
+    gender :: Maybe Text,
+    hazardous_valid_till :: Maybe Text,
+    hill_valid_till :: Maybe Text,
+    id_number :: Maybe Text,
+    issuing_rto_name :: Maybe Text,
+    last_transacted_at :: Maybe Text,
+    name :: Maybe Text,
+    nt_validity_from :: Maybe Text,
+    nt_validity_to :: Maybe Text,
+    relatives_name :: Maybe Text,
+    source :: Maybe Text,
+    status :: Maybe Text,
+    t_validity_from :: Maybe Text,
+    t_validity_to :: Maybe Text,
+    cov_details :: Maybe [CovDetail]
+  }
+  deriving (Show, Generic, ToJSON, FromJSON, ToSchema)
+
+data CovDetail = CovDetail
+  { category :: Maybe Text,
+    cov :: Text,
+    issue_date :: Maybe Text
+  }
+  deriving (Show, Generic, ToJSON, FromJSON, ToSchema)
+
+-- validate image
+data ValidateResponse = ValidateResponse
+  { detected_doc_type :: Text,
+    is_readable :: Maybe Bool,
+    readability :: ReadabilityBody
+  }
+  deriving (Show, Generic, ToJSON, FromJSON, ToSchema)
+
+data ReadabilityBody = ReadabilityBody
+  { confidence :: Maybe Int,
+    dummyField :: Maybe Text
+  }
+  deriving (Show, Generic, ToJSON, FromJSON, ToSchema)
+
+-- DL extract response
+data DLExtractionOutput = DLExtractionOutput
+  { id_number :: Maybe Text,
+    name_on_card :: Maybe Text,
+    fathers_name :: Maybe Text,
+    date_of_birth :: Maybe Text,
+    date_of_validity :: Maybe Text,
+    address :: Maybe Text,
+    district :: Maybe Text,
+    street_address :: Maybe Text,
+    pincode :: Maybe Text,
+    state :: Maybe Text,
+    issue_dates :: Maybe ValidateIssueDate,
+    _type :: [Text],
+    validity :: Maybe Validity,
+    status :: Maybe Text
+  }
+  deriving (Show, Generic)
+
+instance ToSchema DLExtractionOutput where
+  declareNamedSchema = genericDeclareNamedSchema $ fromAesonOptions stripPrefixUnderscoreIfAny
+
+instance FromJSON DLExtractionOutput where
+  parseJSON = genericParseJSON stripPrefixUnderscoreIfAny
+
+instance ToJSON DLExtractionOutput where
+  toJSON = genericToJSON stripPrefixUnderscoreIfAny
+
+data Validity = Validity
+  { nt :: Maybe Text,
+    t :: Maybe Text
+  }
+  deriving (Show, Generic)
+
+instance ToSchema Validity where
+  declareNamedSchema = genericDeclareNamedSchema $ fromAesonOptions constructorsToUpperOptions
+
+instance FromJSON Validity where
+  parseJSON = genericParseJSON constructorsToUpperOptions
+
+instance ToJSON Validity where
+  toJSON = genericToJSON constructorsToUpperOptions
+
+data ValidateIssueDate = ValidateIssueDate
+  { lmv :: Maybe Text,
+    mcwg :: Maybe Text,
+    trans :: Maybe Text
+  }
+  deriving (Show, Generic)
+
+instance ToSchema ValidateIssueDate where
+  declareNamedSchema = genericDeclareNamedSchema $ fromAesonOptions constructorsToUpperOptions
+
+instance FromJSON ValidateIssueDate where
+  parseJSON = genericParseJSON constructorsToUpperOptions
+
+instance ToJSON ValidateIssueDate where
+  toJSON = genericToJSON constructorsToUpperOptions
+
+-- RC Extraction
+data RCExtractionOutput = RCExtractionOutput
+  { address :: Maybe Text,
+    body :: Maybe Text,
+    chassis_number :: Maybe Text,
+    _class :: Maybe Text,
+    colour :: Maybe Text,
+    cubic_capacity :: Maybe Text,
+    document1_side :: Maybe Text,
+    document2_side :: Maybe Text,
+    engine_number :: Maybe Text,
+    fathers_name :: Maybe Text,
+    fuel :: Maybe Text,
+    manufacturer :: Maybe Text,
+    manufacturing_date :: Maybe Text,
+    model :: Maybe Text,
+    owner_name :: Maybe Text,
+    registration_date :: Maybe Text,
+    registration_number :: Maybe Text,
+    rto_district :: Maybe Text,
+    state :: Maybe Text,
+    wheel_base :: Maybe Text,
+    status :: Maybe Text
+  }
+  deriving (Show, Generic)
+
+instance ToSchema RCExtractionOutput where
+  declareNamedSchema = genericDeclareNamedSchema $ fromAesonOptions stripPrefixUnderscoreIfAny
+
+instance FromJSON RCExtractionOutput where
+  parseJSON = genericParseJSON stripPrefixUnderscoreIfAny
+
+instance ToJSON RCExtractionOutput where
+  toJSON = genericToJSON stripPrefixUnderscoreIfAny

--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/WebhookHandler.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/WebhookHandler.hs
@@ -1,0 +1,60 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.Verification.Idfy.WebhookHandler where
+
+import Data.Aeson.Types as DAT
+import EulerHS.Prelude
+import Kernel.External.Verification.Idfy.Auth
+import Kernel.External.Verification.Idfy.Config
+import Kernel.External.Verification.Idfy.Types.Response
+import Kernel.Tools.Metrics.CoreMetrics.Types
+import Kernel.Utils.Common
+import Kernel.Utils.IOLogging
+
+webhookHandler ::
+  ( EncFlow m r,
+    HasField "isShuttingDown" r (TMVar ()),
+    HasField "coreMetrics" r CoreMetricsContainer,
+    HasField "loggerEnv" r LoggerEnv
+  ) =>
+  IdfyCfg ->
+  (VerificationResponse -> Text -> m AckResponse) ->
+  Maybe Text ->
+  Value ->
+  m AckResponse
+webhookHandler cfg verifyHandler secret val = do
+  withLogTag "webhookIdfy" $ do
+    let respDump = encodeToText val
+    let mResp = fromJSON val
+    case mResp of
+      DAT.Success (resp :: VerificationResponse) -> do
+        void $ verifyAuth cfg secret
+        void $ verifyHandler resp respDump
+        pure Ack
+      DAT.Error err1 -> do
+        logInfo $ "Error 1: " <> show err1
+        let mRespList = fromJSON val
+        case mRespList of
+          DAT.Success (respList :: VerificationResponseList) -> do
+            let mResp_ = listToMaybe respList
+            case mResp_ of
+              Just resp_ -> do
+                void $ verifyAuth cfg secret
+                void $ verifyHandler resp_ respDump
+                pure Ack
+              Nothing -> pure Ack
+          DAT.Error err -> do
+            logInfo $ "Error 2: " <> show err
+            pure Ack

--- a/lib/mobility-core/src/Kernel/External/Verification/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Interface.hs
@@ -1,0 +1,80 @@
+{-
+ Copyright 2022-23, Juspay India Pvt Ltd
+
+ This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+ as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program
+
+ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of
+
+ the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.Verification.Interface
+  ( module Reexport,
+    verifyDLAsync,
+    verifyRCAsync,
+    validateImage,
+    extractRCImage,
+    extractDLImage,
+  )
+where
+
+import Kernel.External.Verification.Idfy.Config as Reexport
+import qualified Kernel.External.Verification.Interface.Idfy as Idfy
+import Kernel.External.Verification.Interface.Types as Reexport
+import Kernel.External.Verification.Types as Reexport
+import Kernel.Tools.Metrics.CoreMetrics.Types
+import Kernel.Types.Common
+
+verifyDLAsync ::
+  ( EncFlow m r,
+    CoreMetrics m
+  ) =>
+  VerificationServiceConfig ->
+  VerifyDLAsyncReq ->
+  m VerifyDLAsyncResp
+verifyDLAsync serviceConfig req = case serviceConfig of
+  IdfyConfig cfg -> Idfy.verifyDLAsync cfg req
+
+verifyRCAsync ::
+  ( EncFlow m r,
+    CoreMetrics m
+  ) =>
+  VerificationServiceConfig ->
+  VerifyRCAsyncReq ->
+  m VerifyRCAsyncResp
+verifyRCAsync serviceConfig req = case serviceConfig of
+  IdfyConfig cfg -> Idfy.verifyRCAsync cfg req
+
+validateImage ::
+  ( EncFlow m r,
+    CoreMetrics m
+  ) =>
+  VerificationServiceConfig ->
+  ValidateImageReq ->
+  m ValidateImageResp
+validateImage serviceConfig req = case serviceConfig of
+  IdfyConfig cfg -> Idfy.validateImage cfg req
+
+extractRCImage ::
+  ( EncFlow m r,
+    CoreMetrics m
+  ) =>
+  VerificationServiceConfig ->
+  ExtractRCImageReq ->
+  m ExtractRCImageResp
+extractRCImage serviceConfig req = case serviceConfig of
+  IdfyConfig cfg -> Idfy.extractRCImage cfg req
+
+extractDLImage ::
+  ( EncFlow m r,
+    CoreMetrics m
+  ) =>
+  VerificationServiceConfig ->
+  ExtractDLImageReq ->
+  m ExtractDLImageResp
+extractDLImage serviceConfig req = case serviceConfig of
+  IdfyConfig cfg -> Idfy.extractDLImage cfg req

--- a/lib/mobility-core/src/Kernel/External/Verification/Interface/Idfy.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Interface/Idfy.hs
@@ -1,0 +1,207 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.Verification.Interface.Idfy
+  ( module Reexport,
+    verifyDLAsync,
+    verifyRCAsync,
+    validateImage,
+    extractRCImage,
+    extractDLImage,
+    getTask,
+  )
+where
+
+import qualified Data.Text as T
+import Data.Time.Format
+import Kernel.External.Encryption
+import Kernel.External.Verification.Idfy.Auth as Reexport
+import qualified Kernel.External.Verification.Idfy.Client as Idfy
+import Kernel.External.Verification.Idfy.Config as Reexport
+import Kernel.External.Verification.Idfy.Flow as Reexport
+import Kernel.External.Verification.Idfy.Types as Reexport
+import qualified Kernel.External.Verification.Idfy.Types.Request as Idfy
+import qualified Kernel.External.Verification.Idfy.Types.Response as Idfy
+import Kernel.External.Verification.Interface.Types
+import Kernel.Prelude
+import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
+import Kernel.Types.Common
+
+buildIdfyRequest :: MonadGuid m => a -> m (Idfy.IdfyRequest a)
+buildIdfyRequest a = do
+  task_id <- generateGUID
+  group_id <- generateGUID
+  pure
+    Idfy.IdfyRequest
+      { _data = a,
+        ..
+      }
+
+verifyDLAsync ::
+  ( EncFlow m r,
+    CoreMetrics m
+  ) =>
+  IdfyCfg ->
+  VerifyDLAsyncReq ->
+  m VerifyDLAsyncResp
+verifyDLAsync cfg req = do
+  let url = cfg.url
+  apiKey <- decrypt cfg.apiKey
+  accountId <- decrypt cfg.accountId
+  let dobDay = T.pack $ formatTime defaultTimeLocale "%F" req.dateOfBirth
+  let reqData =
+        Idfy.DLVerificationData
+          { id_number = req.dlNumber,
+            date_of_birth = dobDay
+          }
+  idfyReq <- buildIdfyRequest reqData
+  idfySuccess <- Idfy.verifyDLAsync apiKey accountId url idfyReq
+  pure $ VerifyAsyncResp {requestId = idfySuccess.request_id}
+
+verifyRCAsync ::
+  ( EncFlow m r,
+    CoreMetrics m
+  ) =>
+  IdfyCfg ->
+  VerifyRCAsyncReq ->
+  m VerifyRCAsyncResp
+verifyRCAsync cfg req = do
+  let url = cfg.url
+  apiKey <- decrypt cfg.apiKey
+  accountId <- decrypt cfg.accountId
+  let reqData =
+        Idfy.RCVerificationData
+          { rc_number = req.rcNumber,
+            _a = Nothing
+          }
+  idfyReq <- buildIdfyRequest reqData
+  idfySuccess <- Idfy.verifyRCAsync apiKey accountId url idfyReq
+  pure $ VerifyAsyncResp {requestId = idfySuccess.request_id}
+
+validateImage ::
+  ( EncFlow m r,
+    CoreMetrics m
+  ) =>
+  IdfyCfg ->
+  ValidateImageReq ->
+  m ValidateImageResp
+validateImage cfg req = do
+  -- skipping validation for rc as validation not available in idfy
+  case req.imageType of
+    DriverLicense -> do
+      let url = cfg.url
+      apiKey <- decrypt cfg.apiKey
+      accountId <- decrypt cfg.accountId
+      let reqData =
+            Idfy.ValidateRequest
+              { document1 = req.image,
+                doc_type = getDocType req.imageType
+              }
+      idfyReq <- buildIdfyRequest reqData
+      resp <- Idfy.validateImage apiKey accountId url idfyReq
+      pure $ mkValidateImageResp resp
+    VehicleRegistrationCertificate -> do
+      pure
+        ValidateImageResp
+          { validationAvailable = False,
+            detectedImage = Nothing
+          }
+
+mkValidateImageResp :: Idfy.IdfyResponse Idfy.ValidateResponse -> ValidateImageResp
+mkValidateImageResp resp = do
+  let detectedImage =
+        resp.result <&> \result ->
+          DetectedImage
+            { imageType = getImageType result.detected_doc_type,
+              isReadable = result.is_readable,
+              confidence = result.readability.confidence
+            }
+  ValidateImageResp
+    { validationAvailable = True,
+      detectedImage
+    }
+
+getDocType :: ImageType -> Text
+getDocType DriverLicense = "ind_driving_license"
+getDocType VehicleRegistrationCertificate = "ind_rc"
+
+getImageType :: Text -> ImageType
+getImageType "ind_driving_license" = DriverLicense
+getImageType "ind_rc" = VehicleRegistrationCertificate
+getImageType _ = VehicleRegistrationCertificate
+
+extractRCImage ::
+  ( EncFlow m r,
+    CoreMetrics m
+  ) =>
+  IdfyCfg ->
+  ExtractRCImageReq ->
+  m ExtractRCImageResp
+extractRCImage cfg req = do
+  let url = cfg.url
+  apiKey <- decrypt cfg.apiKey
+  accountId <- decrypt cfg.accountId
+  let reqData =
+        Idfy.ExtractRequest
+          { document1 = req.image1,
+            document2 = req.image2
+          }
+  idfyReq <- buildIdfyRequest reqData
+  resp <- Idfy.extractRCImage apiKey accountId url idfyReq
+  pure
+    ExtractRCImageResp
+      { extractedRC =
+          resp.result <&> \result -> do
+            ExtractedRC {rcNumber = result.extraction_output.registration_number}
+      }
+
+extractDLImage ::
+  ( EncFlow m r,
+    CoreMetrics m
+  ) =>
+  IdfyCfg ->
+  ExtractDLImageReq ->
+  m ExtractDLImageResp
+extractDLImage cfg req = do
+  let url = cfg.url
+  apiKey <- decrypt cfg.apiKey
+  accountId <- decrypt cfg.accountId
+  let reqData =
+        Idfy.ExtractRequest
+          { document1 = req.image1,
+            document2 = req.image2
+          }
+  idfyReq <- buildIdfyRequest reqData
+  resp <- Idfy.extractDLImage apiKey accountId url idfyReq
+  pure
+    ExtractDLImageResp
+      { extractedDL =
+          resp.result <&> \result -> do
+            ExtractedDL {dlNumber = result.extraction_output.id_number}
+      }
+
+-- not used in interface
+
+getTask ::
+  ( EncFlow m r,
+    CoreMetrics m
+  ) =>
+  IdfyCfg ->
+  GetTaskReq ->
+  m GetTaskResp
+getTask cfg req = do
+  let url = cfg.url
+  apiKey <- decrypt cfg.apiKey
+  accountId <- decrypt cfg.accountId
+  Idfy.getTask apiKey accountId url req

--- a/lib/mobility-core/src/Kernel/External/Verification/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Interface/Types.hs
@@ -1,0 +1,107 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module Kernel.External.Verification.Interface.Types
+  ( module Kernel.External.Verification.Interface.Types,
+  )
+where
+
+import Deriving.Aeson
+import qualified Kernel.External.Verification.Idfy.Config as Idfy
+import qualified Kernel.External.Verification.Idfy.Types.Response as Idfy
+import Kernel.Prelude
+
+newtype VerificationServiceConfig = IdfyConfig Idfy.IdfyCfg
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+data VerifyDLAsyncReq = VerifyDLAsyncReq
+  { dlNumber :: Text,
+    dateOfBirth :: UTCTime
+  }
+  deriving stock (Show, Generic)
+
+type VerifyDLAsyncResp = VerifyAsyncResp
+
+newtype VerifyRCAsyncReq = VerifyRCAsyncReq
+  { rcNumber :: Text
+  }
+  deriving stock (Show, Generic)
+
+type VerifyRCAsyncResp = VerifyAsyncResp
+
+newtype VerifyAsyncResp = VerifyAsyncResp
+  { requestId :: Text
+  }
+  deriving stock (Show, Generic)
+
+data ValidateImageReq = ValidateImageReq
+  { image :: Text,
+    imageType :: ImageType
+  }
+  deriving stock (Show, Generic)
+
+data ImageType = DriverLicense | VehicleRegistrationCertificate
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (FromJSON, ToJSON, ToSchema)
+
+data ValidateImageResp = ValidateImageResp
+  { validationAvailable :: Bool,
+    detectedImage :: Maybe DetectedImage
+  }
+  deriving stock (Show, Generic)
+
+data DetectedImage = DetectedImage
+  { imageType :: ImageType,
+    isReadable :: Maybe Bool,
+    confidence :: Maybe Int
+  }
+  deriving stock (Show, Generic)
+
+type ExtractRCImageReq = ExtractImageReq
+
+type ExtractDLImageReq = ExtractImageReq
+
+data ExtractImageReq = ExtractImageReq
+  { image1 :: Text,
+    image2 :: Maybe Text
+  }
+  deriving stock (Show, Generic)
+
+newtype ExtractRCImageResp = ExtractRCImageResp
+  { extractedRC :: Maybe ExtractedRC
+  }
+  deriving stock (Show, Generic)
+
+newtype ExtractedRC = ExtractedRC
+  { rcNumber :: Maybe Text
+  }
+  deriving stock (Show, Generic)
+
+newtype ExtractDLImageResp = ExtractDLImageResp
+  { extractedDL :: Maybe ExtractedDL
+  }
+  deriving stock (Show, Generic)
+
+newtype ExtractedDL = ExtractedDL
+  { dlNumber :: Maybe Text
+  }
+  deriving stock (Show, Generic)
+
+-- not used in interface
+
+type GetTaskReq = Text
+
+type GetTaskResp = Idfy.VerificationResponse

--- a/lib/mobility-core/src/Kernel/External/Verification/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Types.hs
@@ -14,8 +14,8 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Kernel.External.Whatsapp.Types
-  ( module Kernel.External.Whatsapp.Types,
+module Kernel.External.Verification.Types
+  ( module Kernel.External.Verification.Types,
   )
 where
 
@@ -23,10 +23,10 @@ import Data.OpenApi
 import EulerHS.Prelude
 import Kernel.Storage.Esqueleto (derivePersistField)
 
-data WhatsappService = GupShup
+data VerificationService = Idfy
   deriving (Show, Read, Eq, Ord, Generic, ToJSON, FromJSON, ToSchema)
 
-availableWhatsappServices :: [WhatsappService]
-availableWhatsappServices = [GupShup]
+availableVerificationServices :: [VerificationService]
+availableVerificationServices = [Idfy]
 
-derivePersistField "WhatsappService"
+derivePersistField "VerificationService"


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Make IDFY service driver self onboarding as interface

### Additional Changes

- [x] This PR modifies the database schema (database migration added)
- [x] This PR modifies dhall configs/environment variables


## Motivation and Context
We are using idfy as third party service to validate driver documents. Currently this is the only service we are using for this. But in later future we can also use some other services. Make IDFY service as Interface, the way it is done for Maps, SMS, and in this for Call by Alex.

https://github.com/nammayatri/nammayatri/pull/53

Along with that, we will also have the flexibility to add different IDFY credential per merchant, different verification rules per merchant (e.g. for now to verify a DL it needs to be of specific ClassOfVehicle). After this change they should be configurable on basis of merchant.

This Interface is need to onboard new merchant,


## How did you test it?
Did not tested yet

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
