### PR TITLE
Remove duplicate field `colour` from "RCVerificationOutput" record-type

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/Types/Response.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/Types/Response.hs
@@ -116,7 +116,6 @@ data RCVerificationOutput = RCVerificationOutput
     standing_capacity :: Maybe Text,
     status_message :: Maybe Text,
     number_of_cylinder :: Maybe Text,
-    colour :: Maybe Text,
     puc_valid_upto :: Maybe Text,
     permanent_address :: Maybe Text,
     permit_no :: Maybe Text,


### PR DESCRIPTION
* "RCVerificationOutput" record type had duplicate fields of the same name `colour` and same type `Maybe Text`

* Removes the duplicate field `colour` from the record type.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
Fixes #43 

### Additional Changes
No additional changes

## Motivation and Context
please see #43 

## How did you test it?
this was tested running `stack test` and all tests passed.
