### PR TITLE
Backend/feat/#417: version label for metrics

### DIFF
--- a/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics.hs
+++ b/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics.hs
@@ -92,14 +92,14 @@ addRequestLatencyImplementation' ::
   Text ->
   Milliseconds ->
   Either ClientError a ->
-  Version ->
+  DeploymentVersion ->
   m ()
 addRequestLatencyImplementation' cmContainer host serviceName dur status version = do
   let requestLatencyMetric = cmContainer.requestLatency
   L.runIO $
     P.withLabel
       requestLatencyMetric
-      (host, serviceName, status', version.getVersion)
+      (host, serviceName, status', version.getDeploymentVersion)
       (`P.observe` ((/ 1000) . fromIntegral $ getMilliseconds dur))
   where
     status' =
@@ -111,7 +111,7 @@ addRequestLatencyImplementation' cmContainer host serviceName dur status version
         Left (UnsupportedContentType _ (Response code _ _ _)) -> show code
         Left (ConnectionError _) -> "Connection error"
 
-incrementErrorCounterImplementation' :: L.MonadFlow m => CoreMetricsContainer -> Text -> SomeException -> Version -> m ()
+incrementErrorCounterImplementation' :: L.MonadFlow m => CoreMetricsContainer -> Text -> SomeException -> DeploymentVersion -> m ()
 incrementErrorCounterImplementation' cmContainers errorContext exc version
   | Just (HTTPException err) <- fromException exc = incCounter' err
   | Just (BaseException err) <- fromException exc = incCounter' . InternalError . fromMaybe (show err) $ toMessage err
@@ -124,23 +124,23 @@ incrementErrorCounterImplementation' cmContainers errorContext exc version
       L.runIO $
         P.withLabel
           errorCounterMetric
-          (show $ toHttpCode err, errorContext, toErrorCode err, version.getVersion)
+          (show $ toHttpCode err, errorContext, toErrorCode err, version.getDeploymentVersion)
           P.incCounter
 
-addUrlCallRetriesImplementation' :: L.MonadFlow m => CoreMetricsContainer -> BaseUrl -> Int -> Version -> m ()
+addUrlCallRetriesImplementation' :: L.MonadFlow m => CoreMetricsContainer -> BaseUrl -> Int -> DeploymentVersion -> m ()
 addUrlCallRetriesImplementation' cmContainers url retryCount version = do
   let urlCallRetriesMetric = cmContainers.urlCallRetries
   L.runIO $
     P.withLabel
       urlCallRetriesMetric
-      (showBaseUrlText url, show retryCount, version.getVersion)
+      (showBaseUrlText url, show retryCount, version.getDeploymentVersion)
       P.incCounter
 
-addUrlCallFailuresImplementation' :: L.MonadFlow m => CoreMetricsContainer -> BaseUrl -> Version -> m ()
+addUrlCallFailuresImplementation' :: L.MonadFlow m => CoreMetricsContainer -> BaseUrl -> DeploymentVersion -> m ()
 addUrlCallFailuresImplementation' cmContainers url version = do
   let urlCallRetriesMetric = cmContainers.urlCallRetryFailures
   L.runIO $
     P.withLabel
       urlCallRetriesMetric
-      (showBaseUrlText url, version.getVersion)
+      (showBaseUrlText url, version.getDeploymentVersion)
       P.incCounter

--- a/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics/Types.hs
+++ b/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics/Types.hs
@@ -16,6 +16,7 @@ module Kernel.Tools.Metrics.CoreMetrics.Types
   ( HasCoreMetrics,
     CoreMetrics (..),
     CoreMetricsContainer (..),
+    Version (..),
     registerCoreMetricsContainer,
   )
 where
@@ -36,8 +37,10 @@ type URLCallRetryFailuresMetric = P.Vector P.Label2 P.Counter
 
 type HasCoreMetrics r =
   ( HasField "coreMetrics" r CoreMetricsContainer,
-    HasField "version" r Text
+    HasField "version" r Version
   )
+
+newtype Version = Version {getVersion :: Text}
 
 class CoreMetrics m where
   addRequestLatency ::

--- a/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics/Types.hs
+++ b/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics/Types.hs
@@ -26,16 +26,17 @@ import Kernel.Types.Time (Milliseconds)
 import Prometheus as P
 import Servant.Client (BaseUrl, ClientError)
 
-type RequestLatencyMetric = P.Vector P.Label3 P.Histogram
+type RequestLatencyMetric = P.Vector P.Label4 P.Histogram
 
-type ErrorCounterMetric = P.Vector P.Label3 P.Counter
+type ErrorCounterMetric = P.Vector P.Label4 P.Counter
 
-type URLCallRetriesMetric = P.Vector P.Label2 P.Counter
+type URLCallRetriesMetric = P.Vector P.Label3 P.Counter
 
-type URLCallRetryFailuresMetric = P.Vector P.Label1 P.Counter
+type URLCallRetryFailuresMetric = P.Vector P.Label2 P.Counter
 
 type HasCoreMetrics r =
-  ( HasField "coreMetrics" r CoreMetricsContainer
+  ( HasField "coreMetrics" r CoreMetricsContainer,
+    HasField "version" r Text
   )
 
 class CoreMetrics m where
@@ -68,7 +69,7 @@ registerCoreMetricsContainer = do
 registerRequestLatencyMetric :: IO RequestLatencyMetric
 registerRequestLatencyMetric =
   P.register $
-    P.vector ("host", "service", "status") $
+    P.vector ("host", "service", "status", "version") $
       P.histogram info P.defaultBuckets
   where
     info = P.Info "external_request_duration" ""
@@ -76,7 +77,7 @@ registerRequestLatencyMetric =
 registerErrorCounterMetric :: IO ErrorCounterMetric
 registerErrorCounterMetric =
   P.register $
-    P.vector ("HttpCode", "ErrorContext", "ErrorCode") $
+    P.vector ("HttpCode", "ErrorContext", "ErrorCode", "version") $
       P.counter info
   where
     info = P.Info "error_counter" ""
@@ -84,7 +85,7 @@ registerErrorCounterMetric =
 registerURLCallRetriesMetric :: IO URLCallRetriesMetric
 registerURLCallRetriesMetric =
   P.register $
-    P.vector ("URL", "RetryCount") $
+    P.vector ("URL", "RetryCount", "version") $
       P.counter info
   where
     info = P.Info "url_call_retries_counter" ""
@@ -92,7 +93,7 @@ registerURLCallRetriesMetric =
 registerURLCallRetryFailuresMetric :: IO URLCallRetryFailuresMetric
 registerURLCallRetryFailuresMetric =
   P.register $
-    P.vector "URL" $
+    P.vector ("URL", "version") $
       P.counter info
   where
     info = P.Info "url_call_retry_failures_counter" ""

--- a/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics/Types.hs
+++ b/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics/Types.hs
@@ -16,7 +16,7 @@ module Kernel.Tools.Metrics.CoreMetrics.Types
   ( HasCoreMetrics,
     CoreMetrics (..),
     CoreMetricsContainer (..),
-    Version (..),
+    DeploymentVersion (..),
     registerCoreMetricsContainer,
   )
 where
@@ -37,10 +37,10 @@ type URLCallRetryFailuresMetric = P.Vector P.Label2 P.Counter
 
 type HasCoreMetrics r =
   ( HasField "coreMetrics" r CoreMetricsContainer,
-    HasField "version" r Version
+    HasField "version" r DeploymentVersion
   )
 
-newtype Version = Version {getVersion :: Text}
+newtype DeploymentVersion = DeploymentVersion {getDeploymentVersion :: Text}
 
 class CoreMetrics m where
   addRequestLatency ::

--- a/lib/mobility-core/src/Kernel/Utils/App.hs
+++ b/lib/mobility-core/src/Kernel/Utils/App.hs
@@ -23,7 +23,7 @@ module Kernel.Utils.App
     withModifiedEnv,
     hashBodyForSignature,
     getPodName,
-    getVersion,
+    getDeploymentVersion,
     supportProxyAuthorization,
     logRequestAndResponseGeneric,
     withModifiedEnvGeneric,
@@ -40,6 +40,7 @@ import qualified Data.Text as T (pack)
 import Data.UUID.V4 (nextRandom)
 import qualified EulerHS.Language as L
 import EulerHS.Prelude hiding (unpack)
+import Kernel.Tools.Metrics.CoreMetrics (Version (Version))
 import Kernel.Types.App
 import Kernel.Types.Flow
 import Kernel.Utils.Common
@@ -191,5 +192,5 @@ withModifiedEnvGeneric f env = \req resp -> do
 getPodName :: IO (Maybe Text)
 getPodName = fmap T.pack <$> lookupEnv "POD_NAME"
 
-getVersion :: IO Text
-getVersion = T.pack . fromMaybe "DEV" <$> lookupEnv "DEPLOYMENT_VERSION"
+getDeploymentVersion :: IO Version
+getDeploymentVersion = Version . T.pack . fromMaybe "DEV" <$> lookupEnv "DEPLOYMENT_VERSION"

--- a/lib/mobility-core/src/Kernel/Utils/App.hs
+++ b/lib/mobility-core/src/Kernel/Utils/App.hs
@@ -23,7 +23,7 @@ module Kernel.Utils.App
     withModifiedEnv,
     hashBodyForSignature,
     getPodName,
-    getDeploymentVersion,
+    lookupDeploymentVersion,
     supportProxyAuthorization,
     logRequestAndResponseGeneric,
     withModifiedEnvGeneric,
@@ -40,7 +40,7 @@ import qualified Data.Text as T (pack)
 import Data.UUID.V4 (nextRandom)
 import qualified EulerHS.Language as L
 import EulerHS.Prelude hiding (unpack)
-import Kernel.Tools.Metrics.CoreMetrics (Version (Version))
+import Kernel.Tools.Metrics.CoreMetrics (DeploymentVersion (..))
 import Kernel.Types.App
 import Kernel.Types.Flow
 import Kernel.Utils.Common
@@ -192,5 +192,5 @@ withModifiedEnvGeneric f env = \req resp -> do
 getPodName :: IO (Maybe Text)
 getPodName = fmap T.pack <$> lookupEnv "POD_NAME"
 
-getDeploymentVersion :: IO Version
-getDeploymentVersion = Version . T.pack . fromMaybe "DEV" <$> lookupEnv "DEPLOYMENT_VERSION"
+lookupDeploymentVersion :: IO DeploymentVersion
+lookupDeploymentVersion = DeploymentVersion . T.pack . fromMaybe "DEV" <$> lookupEnv "DEPLOYMENT_VERSION"

--- a/lib/mobility-core/src/Kernel/Utils/App.hs
+++ b/lib/mobility-core/src/Kernel/Utils/App.hs
@@ -23,6 +23,7 @@ module Kernel.Utils.App
     withModifiedEnv,
     hashBodyForSignature,
     getPodName,
+    getVersion,
     supportProxyAuthorization,
     logRequestAndResponseGeneric,
     withModifiedEnvGeneric,
@@ -189,3 +190,6 @@ withModifiedEnvGeneric f env = \req resp -> do
 
 getPodName :: IO (Maybe Text)
 getPodName = fmap T.pack <$> lookupEnv "POD_NAME"
+
+getVersion :: IO Text
+getVersion = T.pack . fromMaybe "DEV" <$> lookupEnv "DEPLOYMENT_VERSION"

--- a/lib/mobility-core/src/Kernel/Utils/Predicates.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Predicates.hs
@@ -11,7 +11,6 @@
 
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# OPTIONS_GHC -Wno-missing-signatures #-}
 
 module Kernel.Utils.Predicates where
 
@@ -26,13 +25,17 @@ latin = latinUC \/ latinLC
 alphanum = latin \/ digit
 latinOrSpace = latin \/ " "
 
+mobileNumber :: ExactLength `And` Regex
 mobileNumber = ExactLength 10 `And` star digit
 
+mobileCountryCode :: LengthInRange `And` Regex
 mobileCountryCode = LengthInRange 2 4 `And` ("+" <> star digit)
 
+fullMobilePhone :: LengthInRange `And` Regex
 fullMobilePhone = LengthInRange 12 14 `And` ("+" <> star digit)
 
 mobileIndianCode :: Regex
 mobileIndianCode = "+91"
 
+name :: Regex
 name = star latinOrSpace


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Prometheus metrics being generated by the container needs to have additional version label which will be used for filtering out metrics.

version can be fetched from DEPLOYMENT_VERSION env variable.
https://github.com/nammayatri/nammayatri/issues/417


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
