### PR TITLE
backend/feat: #616 snapToRoadSnippetThreshold for OSRM

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Maps/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Interface.hs
@@ -124,7 +124,7 @@ snapToRoadProvided = \case
 snapToRoad ::
   ( EncFlow m r,
     CoreMetrics m,
-    HasField "snapToRoadSnippetThreshold" r HighPrecMeters
+    HasFlowEnv m r '["snapToRoadSnippetThreshold" ::: HighPrecMeters]
   ) =>
   MapsServiceConfig ->
   SnapToRoadReq ->


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
In case of OSRM, we don't use snapToRoadSnippetThreshold as in other services, because we use distance from API response field resp.matchings[0].distance, not calculating by ourselves. But still we need to check for inaccurate location updates.


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Tested locally

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
