### PR TITLE
jenkins: Explicitly run on nixos

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent any
+    agent { label 'nixos' }
     stages {
         stage ('Cachix setup') {
             steps {


### PR DESCRIPTION
We are soon adding a macos slave, so let's be explicit here.
