### PR TITLE
jenkins: Build on macOS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,22 +1,41 @@
 pipeline {
-    agent { label 'nixos' }
+    agent {
+        label 'nixos'
+    }
     stages {
-        stage ('Cachix setup') {
-            steps {
-                cachixUse "nammayatri"
-            }
-        }
-        stage ('Nix Build All') {
-            steps {
-                nixBuildAll ()
-            }
-        }
-        stage ('Cachix push') {
-            when {
-                anyOf { branch 'main'; branch 'prodHotPush' }
-            }
-            steps {
-                cachixPush "nammayatri"
+        stage ('Platform Matrix') {
+            matrix {
+                agent {
+                    label "${PLATFORM}"
+                }
+                axes {
+                    axis {
+                        name 'PLATFORM'
+                        values 'nixos', 'macos'
+                    }
+                }
+                stages {
+                    stage ('Cachix setup') {
+                        steps {
+                            cachixUse "nammayatri"
+                        }
+                    }
+                    stage ('Nix Build All') {
+                        steps {
+                            nixBuildAll ()
+                        }
+                    }
+                    stage ('Cachix push') {
+                        when {
+                            anyOf {
+                                branch 'main'; branch 'prodHotPush'
+                            }
+                        }
+                        steps {
+                            cachixPush "nammayatri"
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This uses the WIP macOS support branch of https://github.com/juspay/jenkins-nix-ci to run CI on a macOS machine (Mac Studio in office).