### PR TITLE
jenkins: Build on Intel macOS and push to cachix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,16 +2,19 @@ pipeline {
     agent {
         label 'nixos'
     }
+    options {
+        parallelsAlwaysFailFast()
+    }
     stages {
-        stage ('Platform Matrix') {
+        stage ('Matrix') {
             matrix {
                 agent {
-                    label "${PLATFORM}"
+                    label "${SYSTEM}"
                 }
                 axes {
                     axis {
-                        name 'PLATFORM'
-                        values 'nixos', 'macos'
+                        name 'SYSTEM'
+                        values 'x86_64-linux', 'aarch64-darwin', 'x86_64-darwin'
                     }
                 }
                 stages {
@@ -22,7 +25,7 @@ pipeline {
                     }
                     stage ('Nix Build All') {
                         steps {
-                            nixBuildAll ()
+                            nixBuildAll system: env.SYSTEM
                         }
                     }
                     stage ('Cachix push') {


### PR DESCRIPTION
According to Ritika Jindal, 5-6 team members are still on Intel mac, so we must do Rosetta build in CI and push to cachix.

**Tasks**

- [x] Working `Jenkinsfile`
- [x] jenkins-nix-ci: `cachixPush` must be made system-aware, somehow
- ~~[ ] Upstream the matrix configuration as Groovy library?~~ No necessary, as groovy code is simplified enough