### PR TITLE
backend/feat: #769 version label for middleware metrics

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -302,6 +302,24 @@
         "type": "github"
       }
     },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_3"
+      },
+      "locked": {
+        "lastModified": 1683560683,
+        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-root": {
       "locked": {
         "lastModified": 1680210152,
@@ -431,6 +449,21 @@
         "owner": "srid",
         "repo": "haskell-flake",
         "rev": "7997b6fc5dc2f5beb1bbdbb7a5bbed2e6c530dac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "type": "github"
+      }
+    },
+    "haskell-flake_3": {
+      "locked": {
+        "lastModified": 1683641774,
+        "narHash": "sha256-6clCN5n/qd5/hk/f+M+4sr1VVs/sEgwH+sgE7PkKQOc=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "ebfe70269fce376a7c95d6e9f011e16cbfd29b8d",
         "type": "github"
       },
       "original": {
@@ -662,6 +695,24 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_3": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -806,6 +857,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_8": {
+      "locked": {
+        "lastModified": 1683657389,
+        "narHash": "sha256-jx91UqqoBneE8QPAKJA29GANrU/Z7ULghoa/JE0+Edw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9524f57dd5b3944c819dd594aed8ed941932ef56",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "passetto-hs": {
       "flake": false,
       "locked": {
@@ -908,7 +975,8 @@
           "nixpkgs"
         ],
         "passetto-hs": "passetto-hs",
-        "systems": "systems"
+        "systems": "systems",
+        "wai-middleware-prometheus": "wai-middleware-prometheus"
       }
     },
     "sequelize": {
@@ -976,6 +1044,27 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "wai-middleware-prometheus": {
+      "inputs": {
+        "flake-parts": "flake-parts_3",
+        "haskell-flake": "haskell-flake_3",
+        "nixpkgs": "nixpkgs_8"
+      },
+      "locked": {
+        "lastModified": 1684305829,
+        "narHash": "sha256-MrM4ZFZuu0e6aVd7ixw5ZNhD4Vcrc6lUL+d1NO7mJ38=",
+        "owner": "juspay",
+        "repo": "prometheus-haskell",
+        "rev": "1104a429745c45f333508c7aa2cd7d6f94b76755",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "ref": "more-proc-metrics",
+        "repo": "prometheus-haskell",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
     passetto-hs.flake = false;
     clickhouse-haskell.url = "github:piyushKumar-1/clickhouse-haskell";
     clickhouse-haskell.flake = false;
+    wai-middleware-prometheus.url = "github:juspay/prometheus-haskell/more-proc-metrics";
 
     euler-hs.url = "github:juspay/euler-hs";
   };
@@ -23,6 +24,7 @@
         haskellProjects.default = {
           imports = [
             inputs.euler-hs.haskellFlakeProjectModules.output
+            inputs.wai-middleware-prometheus.haskellFlakeProjectModules.output
           ];
           source-overrides = {
             passetto-client = inputs.passetto-hs + /client;
@@ -34,6 +36,7 @@
             lib.mapAttrs (k: lib.pipe super.${k}) {
               # Tests and documentation generation fail for some reason.
               euler-hs = [ dontCheck dontHaddock ];
+              wai-middleware-prometheus = [ dontCheck dontHaddock ];
               clickhouse-haskell = [ doJailbreak ];
             };
           autoWire = [ "packages" "checks" ];

--- a/lib/mobility-core/src/Kernel/Tools/Metrics/Init.hs
+++ b/lib/mobility-core/src/Kernel/Tools/Metrics/Init.hs
@@ -18,6 +18,7 @@ module Kernel.Tools.Metrics.Init where
 
 import Data.Text as DT
 import EulerHS.Prelude as E
+import Kernel.Tools.Metrics.CoreMetrics.Types
 import Kernel.Utils.Monitoring.Prometheus.Servant
 import Network.Wai (Application, Request (..))
 import Network.Wai.Handler.Warp as W
@@ -36,10 +37,11 @@ serve port = do
 
 addServantInfo ::
   SanitizedUrl a =>
+  DeploymentVersion ->
   Proxy a ->
   Application ->
   Application
-addServantInfo proxy app request respond =
+addServantInfo version proxy app request respond =
   let mpath = getSanitizedUrl proxy request
       fullpath = DT.intercalate "/" (pathInfo request)
-   in instrumentHandlerValue (\_ -> "/" <> fromMaybe fullpath mpath) app request respond
+   in instrumentHandlerValueWithVersionLabel version.getDeploymentVersion (\_ -> "/" <> fromMaybe fullpath mpath) app request respond


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
https://github.com/nammayatri/nammayatri/issues/769

To do staggered deployments, we need to compare 4xx/ 5xx b/w the current and previous version across routes.
To monitor through Prom metrics, we need to add the version label in the metric: http_request_duration_seconds_count.


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
Tested locally. Middleware metric `http_request_duration_seconds` worked the same as in master branch, only `version` label added


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
