### PR TITLE
backend/nix: Point to official `clickhouse-haskell` repo

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,17 +91,21 @@
       }
     },
     "clickhouse-haskell": {
-      "flake": false,
+      "inputs": {
+        "common": [
+          "common"
+        ]
+      },
       "locked": {
-        "lastModified": 1676920142,
-        "narHash": "sha256-uEWtTQU+YIB/BWMf8wf+p8pv34W2Ohhv2xigC8YV1PY=",
-        "owner": "piyushKumar-1",
+        "lastModified": 1684938357,
+        "narHash": "sha256-3Qq80uxcFfatfZmsLM/h/aPZYzv1FZ3EEK35NasGQs0=",
+        "owner": "nammayatri",
         "repo": "clickhouse-haskell",
-        "rev": "5eafcf35b7f2f5619f21dbafb55d98b1e57b1d39",
+        "rev": "773517398ae94ca5ad54491cd70d0a1717926192",
         "type": "github"
       },
       "original": {
-        "owner": "piyushKumar-1",
+        "owner": "nammayatri",
         "repo": "clickhouse-haskell",
         "type": "github"
       }
@@ -963,13 +967,34 @@
         "type": "github"
       }
     },
+    "prometheus-haskell": {
+      "inputs": {
+        "flake-parts": "flake-parts_3",
+        "haskell-flake": "haskell-flake_3",
+        "nixpkgs": "nixpkgs_8"
+      },
+      "locked": {
+        "lastModified": 1684305829,
+        "narHash": "sha256-MrM4ZFZuu0e6aVd7ixw5ZNhD4Vcrc6lUL+d1NO7mJ38=",
+        "owner": "juspay",
+        "repo": "prometheus-haskell",
+        "rev": "1104a429745c45f333508c7aa2cd7d6f94b76755",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "ref": "more-proc-metrics",
+        "repo": "prometheus-haskell",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "clickhouse-haskell": "clickhouse-haskell",
         "common": "common",
         "euler-hs": "euler-hs",
         "passetto-hs": "passetto-hs",
-        "wai-middleware-prometheus": "wai-middleware-prometheus"
+        "prometheus-haskell": "prometheus-haskell"
       }
     },
     "sequelize": {
@@ -1037,27 +1062,6 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "wai-middleware-prometheus": {
-      "inputs": {
-        "flake-parts": "flake-parts_3",
-        "haskell-flake": "haskell-flake_3",
-        "nixpkgs": "nixpkgs_8"
-      },
-      "locked": {
-        "lastModified": 1684305829,
-        "narHash": "sha256-MrM4ZFZuu0e6aVd7ixw5ZNhD4Vcrc6lUL+d1NO7mJ38=",
-        "owner": "juspay",
-        "repo": "prometheus-haskell",
-        "rev": "1104a429745c45f333508c7aa2cd7d6f94b76755",
-        "type": "github"
-      },
-      "original": {
-        "owner": "juspay",
-        "ref": "more-proc-metrics",
-        "repo": "prometheus-haskell",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,9 @@
 
     passetto-hs.url = "github:juspay/passetto/bb92cf1dd9699662d2a7bb96cd6a6aed6f20e8ff";
     passetto-hs.flake = false;
-    clickhouse-haskell.url = "github:piyushKumar-1/clickhouse-haskell";
-    clickhouse-haskell.flake = false;
-    wai-middleware-prometheus.url = "github:juspay/prometheus-haskell/more-proc-metrics";
+    clickhouse-haskell.url = "github:nammayatri/clickhouse-haskell";
+    clickhouse-haskell.inputs.common.follows = "common";
+    prometheus-haskell.url = "github:juspay/prometheus-haskell/more-proc-metrics";
 
     euler-hs.url = "github:juspay/euler-hs";
   };
@@ -16,12 +16,12 @@
         haskellProjects.default = {
           imports = [
             inputs.euler-hs.haskellFlakeProjectModules.output
-            inputs.wai-middleware-prometheus.haskellFlakeProjectModules.output
+            inputs.clickhouse-haskell.haskellFlakeProjectModules.output
+            inputs.prometheus-haskell.haskellFlakeProjectModules.output
           ];
           source-overrides = {
             passetto-client = inputs.passetto-hs + /client;
             passetto-core = inputs.passetto-hs + /core;
-            inherit (inputs) clickhouse-haskell;
           };
           overrides = self: super:
             with pkgs.haskell.lib.compose;


### PR DESCRIPTION
Also, use haskell-flake module, rather than source-overrides. And rename the prometheus input for naming consistency.