### PR TITLE
backend/nix: Remove follows, directly use 'common'

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -122,11 +122,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1684874837,
-        "narHash": "sha256-weYj3ysennqz0T6rnRuUkVw/oIVXPq9Re8MLULgPcXk=",
+        "lastModified": 1684876793,
+        "narHash": "sha256-4aBnYmtXjvZXl+K2oYSUHT441Bz+b+vumARUETrzP6Y=",
         "owner": "nammayatri",
         "repo": "common",
-        "rev": "ce76f7392daab845f0eae918167908041a54fdc2",
+        "rev": "4b5d6be277db5d11320d153f7fd17ab3cab4fab5",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -118,14 +118,15 @@
         "nixpkgs-21_11": "nixpkgs-21_11",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "process-compose-flake": "process-compose-flake",
+        "systems": "systems",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1682687568,
-        "narHash": "sha256-X1BiDtvNmAHYcwrYbHFOYfj3U39a+XcT9Eb7rVmq+HY=",
+        "lastModified": 1684874837,
+        "narHash": "sha256-weYj3ysennqz0T6rnRuUkVw/oIVXPq9Re8MLULgPcXk=",
         "owner": "nammayatri",
         "repo": "common",
-        "rev": "c2aacc7499fb452daa61f29f986dc320124d9814",
+        "rev": "ce76f7392daab845f0eae918167908041a54fdc2",
         "type": "github"
       },
       "original": {
@@ -429,15 +430,16 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1682614676,
-        "narHash": "sha256-Eu53z8fdtt8mfMRp+IskjclCT9LqvCViMOzvqO0Rz50=",
+        "lastModified": 1684780604,
+        "narHash": "sha256-2uMZsewmRn7rRtAnnQNw1lj0uZBMh4m6Cs/7dV5YF08=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "11ab35533afaf0cacc5f3ed8032cb2482cedf8fd",
+        "rev": "74210fa80a49f1b6f67223debdbf1494596ff9f2",
         "type": "github"
       },
       "original": {
         "owner": "srid",
+        "ref": "0.3.0",
         "repo": "haskell-flake",
         "type": "github"
       }
@@ -966,16 +968,7 @@
         "clickhouse-haskell": "clickhouse-haskell",
         "common": "common",
         "euler-hs": "euler-hs",
-        "flake-parts": [
-          "common",
-          "flake-parts"
-        ],
-        "nixpkgs": [
-          "common",
-          "nixpkgs"
-        ],
         "passetto-hs": "passetto-hs",
-        "systems": "systems",
         "wai-middleware-prometheus": "wai-middleware-prometheus"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,6 @@
 {
   inputs = {
     common.url = "github:nammayatri/common";
-    nixpkgs.follows = "common/nixpkgs";
-    flake-parts.follows = "common/flake-parts";
-    systems.url = "github:nix-systems/default";
 
     passetto-hs.url = "github:juspay/passetto/bb92cf1dd9699662d2a7bb96cd6a6aed6f20e8ff";
     passetto-hs.flake = false;
@@ -13,9 +10,10 @@
 
     euler-hs.url = "github:juspay/euler-hs";
   };
-  outputs = inputs@{ flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = import inputs.systems;
+  outputs = inputs: inputs.common.inputs.flake-parts.lib.mkFlake
+    { inputs = inputs // { inherit (inputs.common.inputs) nixpkgs; }; }
+    {
+      systems = import inputs.common.inputs.systems;
       imports = [
         inputs.common.flakeModules.default
       ];

--- a/flake.nix
+++ b/flake.nix
@@ -10,14 +10,8 @@
 
     euler-hs.url = "github:juspay/euler-hs";
   };
-  outputs = inputs: inputs.common.inputs.flake-parts.lib.mkFlake
-    { inputs = inputs // { inherit (inputs.common.inputs) nixpkgs; }; }
-    {
-      systems = import inputs.common.inputs.systems;
-      imports = [
-        inputs.common.flakeModules.default
-      ];
-
+  outputs = inputs:
+    inputs.common.lib.mkFlake { inherit inputs; } {
       perSystem = { self', pkgs, lib, config, ... }: {
         haskellProjects.default = {
           imports = [


### PR DESCRIPTION
This trick is necessary to reduce unnecessary duplicate input in the lock file of any repo that uses shared-kernel.