### PR TITLE
nix: Fix cabal cache dir values

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
           inputsFrom = [
             config.haskellProjects.default.outputs.devShell
             config.pre-commit.devShell
+            config.flake-root.devShell
           ];
         };
       };


### PR DESCRIPTION
Without this, people can't run `cabal` in the nix shell. Not sure how we didn't catch this before.