### PR TITLE
backend/refactor: #904 Refactor redis functions for working with two …

### DIFF
--- a/lib/mobility-core/src/Kernel/Storage/Hedis/Config.hs
+++ b/lib/mobility-core/src/Kernel/Storage/Hedis/Config.hs
@@ -21,14 +21,33 @@ import GHC.Records.Extra
 import Kernel.Prelude
 import Kernel.Tools.Metrics.CoreMetrics
 import Kernel.Types.Logging
+import Kernel.Types.MonadGuid (MonadGuid)
 import Kernel.Types.Time
 import Kernel.Utils.Dhall (FromDhall)
 import Network.Socket (HostName)
 
 type HedisFlow m env =
-  (MonadTime m, CoreMetrics m, MonadCatch m, MonadReader env m, HasField "hedisMigrationStage" env Bool, HasField "hedisClusterEnv" env HedisEnv, HasField "hedisNonCriticalClusterEnv" env HedisEnv, HasField "hedisEnv" env HedisEnv, HasField "hedisNonCriticalEnv" env HedisEnv, HasField "enablePrometheusMetricLogging" env Bool, HasField "enableRedisLatencyLogging" env Bool, MonadIO m, C.MonadThrow m, Log m)
+  ( MonadTime m,
+    CoreMetrics m,
+    MonadCatch m,
+    MonadReader env m,
+    HasField "hedisMigrationStage" env Bool,
+    HasField "hedisClusterEnv" env HedisEnv,
+    HasField "hedisNonCriticalClusterEnv" env HedisEnv,
+    HasField "hedisEnv" env HedisEnv,
+    HasField "hedisNonCriticalEnv" env HedisEnv,
+    HasField "enablePrometheusMetricLogging" env Bool,
+    HasField "enableRedisLatencyLogging" env Bool,
+    MonadIO m,
+    C.MonadThrow m,
+    Log m,
+    HasEnvPrefix env,
+    MonadGuid m
+  )
 
 type KeyModifierFunc = (Text -> Text)
+
+type HasEnvPrefix env = (HasField "envPrefix" env Text)
 
 data HedisCfg = HedisCfg
   { connectHost :: HostName,


### PR DESCRIPTION
…keys

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
Added possibility to write two keys for one value in Redis. Now when adding a value to the cache, a unique key is created, with which the added value is associated. The key itself is also stored in Redis. Two keys with environment prefixes are used for it.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context

## How did you test it?

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
