### PR TITLE
backend/fix/payment-integration optional fields for payment txn

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
@@ -43,11 +43,11 @@ newtype OrderStatusReq = OrderStatusReq
 
 data OrderStatusResp = OrderStatusResp
   { orderShortId :: Text,
-    transactionUUID :: Text,
+    transactionUUID :: Maybe Text,
     transactionStatusId :: Int,
     transactionStatus :: TransactionStatus,
-    paymentMethodType :: Text,
-    paymentMethod :: Text,
+    paymentMethodType :: Maybe Text,
+    paymentMethod :: Maybe Text,
     respMessage :: Maybe Text,
     respCode :: Maybe Text,
     gatewayReferenceId :: Maybe Text,

--- a/lib/mobility-core/src/Kernel/External/Payment/Juspay/Types/Common.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Juspay/Types/Common.hs
@@ -56,11 +56,11 @@ type OrderStatusResp = OrderData
 
 data OrderData = OrderData
   { order_id :: Text,
-    txn_uuid :: Text,
+    txn_uuid :: Maybe Text,
     status_id :: Int,
     status :: TransactionStatus,
-    payment_method_type :: Text,
-    payment_method :: Text,
+    payment_method_type :: Maybe Text,
+    payment_method :: Maybe Text,
     resp_message :: Maybe Text,
     resp_code :: Maybe Text,
     gateway_reference_id :: Maybe Text,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Some fields of payment_transaction should be optional (null for new orders) : paymentMethodType, paymentMethod, txn_uuid


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
