### PR TITLE
backend/fix: make create order resp fields optional

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Payment/Juspay/Types/CreateOrder.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Juspay/Types/CreateOrder.hs
@@ -54,8 +54,8 @@ data PaymentLinks = PaymentLinks
   deriving anyclass (FromJSON, ToJSON, ToSchema)
 
 data SDKPayload = SDKPayload
-  { requestId :: Text,
-    service :: Text,
+  { requestId :: Maybe Text,
+    service :: Maybe Text,
     payload :: SDKPayloadDetails
   }
   deriving stock (Show, Eq, Generic)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->
To be merged with https://github.com/nammayatri/nammayatri/pull/1426

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
