### PR TITLE
backend/feat#1394 maps service percentage

### DIFF
--- a/lib/mobility-core/mobility-core.cabal
+++ b/lib/mobility-core/mobility-core.cabal
@@ -449,7 +449,6 @@ library
     , servant-openapi3
     , servant-server
     , slack-web
-    , singletons
     , stm
     , string-conversions
     , tasty
@@ -605,7 +604,6 @@ test-suite mobility-core-tests
     , servant-openapi3
     , servant-server
     , slack-web
-    , singletons
     , stm
     , string-conversions
     , tasty

--- a/lib/mobility-core/mobility-core.cabal
+++ b/lib/mobility-core/mobility-core.cabal
@@ -449,6 +449,7 @@ library
     , servant-openapi3
     , servant-server
     , slack-web
+    , singletons
     , stm
     , string-conversions
     , tasty
@@ -479,6 +480,7 @@ test-suite mobility-core-tests
       APIExceptions
       Centesimal
       DistanceCalculation
+      Randomizer
       SignatureAuth
       SlidingWindowLimiter
       SnippetsCheck
@@ -603,6 +605,7 @@ test-suite mobility-core-tests
     , servant-openapi3
     , servant-server
     , slack-web
+    , singletons
     , stm
     , string-conversions
     , tasty

--- a/lib/mobility-core/package.yaml
+++ b/lib/mobility-core/package.yaml
@@ -92,6 +92,7 @@ dependencies:
   - servant-client-core
   - servant-server
   - servant-openapi3
+  - singletons
   - text
   - wai
   - warp

--- a/lib/mobility-core/package.yaml
+++ b/lib/mobility-core/package.yaml
@@ -92,7 +92,6 @@ dependencies:
   - servant-client-core
   - servant-server
   - servant-openapi3
-  - singletons
   - text
   - wai
   - warp

--- a/lib/mobility-core/src/Kernel/External/Maps/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Interface.hs
@@ -14,23 +14,20 @@
 
 module Kernel.External.Maps.Interface
   ( module Reexport,
+    mapsMethodProvided,
     getDistance,
-    getDistancesProvided,
     getDistances,
-    getRoutesProvided,
     getRoutes,
-    snapToRoadProvided,
     snapToRoad,
     snapToRoadWithFallback,
     autoCompleteProvided,
     autoComplete,
-    getPlaceDetailsProvided,
     getPlaceDetails,
-    getPlaceNameProvided,
     getPlaceName,
   )
 where
 
+import Data.Singletons.TH
 import EulerHS.Prelude ((...))
 import Kernel.External.Maps.Google.Config as Reexport
 import Kernel.External.Maps.HasCoordinates as Reexport (HasCoordinates (..))
@@ -49,6 +46,25 @@ import Kernel.Types.Common hiding (id)
 import Kernel.Types.Error
 import Kernel.Utils.CalculateDistance
 import Kernel.Utils.Common hiding (id)
+
+mapsMethodProvided ::
+  forall (msum :: MapsServiceUsageMethod).
+  (SingI msum) =>
+  SMapsService msum ->
+  Bool
+mapsMethodProvided (SMapsService mapsService) = do
+  let mapsServiceUsageMethod = fromSing (sing @msum)
+  case mapsServiceUsageMethod of
+    GetDistances -> getDistancesProvided mapsService
+    GetEstimatedPickupDistances -> getDistancesProvided mapsService
+    GetRoutes -> getRoutesProvided mapsService
+    GetPickupRoutes -> getRoutesProvided mapsService
+    GetTripRoutes -> getRoutesProvided mapsService
+    SnapToRoad -> snapToRoadProvided mapsService
+    GetPlaceName -> getPlaceNameProvided mapsService
+    GetPlaceDetails -> getPlaceDetailsProvided mapsService
+    AutoComplete -> autoCompleteProvided mapsService
+    GetDistancesForCancelRide -> getDistancesProvided mapsService
 
 getDistance ::
   ( EncFlow m r,
@@ -81,7 +97,7 @@ throwNotProvidedError =
 getDistancesProvided :: MapsService -> Bool
 getDistancesProvided = \case
   Google -> True
-  OSRM -> False
+  OSRM -> True
   MMI -> True
   NextBillion -> False
 
@@ -104,8 +120,8 @@ getDistances serviceConfig req = case serviceConfig of
 getRoutesProvided :: MapsService -> Bool
 getRoutesProvided = \case
   Google -> True
-  OSRM -> False
-  MMI -> False
+  OSRM -> True
+  MMI -> True
   NextBillion -> True
 
 getRoutes ::

--- a/lib/mobility-core/src/Kernel/External/Maps/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Interface.hs
@@ -11,6 +11,7 @@
 
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
+{-# LANGUAGE DerivingStrategies #-}
 
 module Kernel.External.Maps.Interface
   ( module Reexport,
@@ -27,7 +28,6 @@ module Kernel.External.Maps.Interface
   )
 where
 
-import Data.Singletons.TH
 import EulerHS.Prelude ((...))
 import Kernel.External.Maps.Google.Config as Reexport
 import Kernel.External.Maps.HasCoordinates as Reexport (HasCoordinates (..))
@@ -48,23 +48,20 @@ import Kernel.Utils.CalculateDistance
 import Kernel.Utils.Common hiding (id)
 
 mapsMethodProvided ::
-  forall (msum :: MapsServiceUsageMethod).
-  (SingI msum) =>
-  SMapsService msum ->
+  MapsServiceUsageMethod ->
+  MapsService ->
   Bool
-mapsMethodProvided (SMapsService mapsService) = do
-  let mapsServiceUsageMethod = fromSing (sing @msum)
-  case mapsServiceUsageMethod of
-    GetDistances -> getDistancesProvided mapsService
-    GetEstimatedPickupDistances -> getDistancesProvided mapsService
-    GetRoutes -> getRoutesProvided mapsService
-    GetPickupRoutes -> getRoutesProvided mapsService
-    GetTripRoutes -> getRoutesProvided mapsService
-    SnapToRoad -> snapToRoadProvided mapsService
-    GetPlaceName -> getPlaceNameProvided mapsService
-    GetPlaceDetails -> getPlaceDetailsProvided mapsService
-    AutoComplete -> autoCompleteProvided mapsService
-    GetDistancesForCancelRide -> getDistancesProvided mapsService
+mapsMethodProvided = \case
+  GetDistances -> getDistancesProvided
+  GetEstimatedPickupDistances -> getDistancesProvided
+  GetRoutes -> getRoutesProvided
+  GetPickupRoutes -> getRoutesProvided
+  GetTripRoutes -> getRoutesProvided
+  SnapToRoad -> snapToRoadProvided
+  GetPlaceName -> getPlaceNameProvided
+  GetPlaceDetails -> getPlaceDetailsProvided
+  AutoComplete -> autoCompleteProvided
+  GetDistancesForCancelRide -> getDistancesProvided
 
 getDistance ::
   ( EncFlow m r,

--- a/lib/mobility-core/src/Kernel/External/Maps/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Types.hs
@@ -11,6 +11,8 @@
 
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -32,10 +34,32 @@ import EulerHS.Prelude
 import Kernel.Beam.Lib.UtilsTH (mkBeamInstancesForEnumAndList, mkBeamInstancesForList)
 import Kernel.Storage.Esqueleto (derivePersistField)
 import Kernel.Utils.GenericPretty (PrettyShow)
+import Data.Singletons.TH
+import Data.Text hiding (toLower)
+import qualified Database.Beam as B
+import Database.Beam.Backend (BeamSqlBackend, FromBackendRow, HasSqlValueSyntax (sqlValueSyntax), autoSqlValueSyntax)
+import Database.Beam.Postgres (Postgres)
+import Database.PostgreSQL.Simple.FromField (FromField (fromField))
+import qualified GHC.Show as Show
+import Kernel.Prelude
+import Kernel.Storage.Esqueleto (PersistField, PersistFieldSql, derivePersistField)
+import Kernel.Types.Common (fromFieldEnum)
+import Kernel.Utils.GenericPretty (PrettyShow, Showable (..))
 import Servant.API (FromHttpApiData (..), ToHttpApiData (..))
 
 data MapsService = Google | OSRM | MMI | NextBillion
   deriving (Show, Read, Eq, Ord, Generic, ToJSON, FromJSON, ToSchema)
+  deriving (PrettyShow) via Showable MapsService
+
+instance FromField MapsService where
+  fromField = fromFieldEnum
+
+instance HasSqlValueSyntax be String => HasSqlValueSyntax be MapsService where
+  sqlValueSyntax = autoSqlValueSyntax
+
+instance BeamSqlBackend be => B.HasSqlEqualityCheck be MapsService
+
+instance FromBackendRow Postgres MapsService
 
 $(mkBeamInstancesForEnumAndList ''MapsService)
 
@@ -72,3 +96,69 @@ instance FromHttpApiData LatLong where
 instance ToHttpApiData LatLong where
   toQueryParam :: LatLong -> Text
   toQueryParam LatLong {..} = show lat <> "," <> show lon
+
+-- sum should be always 100
+data MapsServiceUsage (msum :: MapsServiceUsageMethod) = MapsServiceUsage
+  { mapsService :: SMapsService msum,
+    usePercentage :: Bool, -- False by default
+    googlePercentage :: Maybe Int,
+    osrmPercentage :: Maybe Int,
+    mmiPercentage :: Maybe Int
+  }
+  deriving (Generic, Show, FromJSON, ToJSON, ToSchema)
+
+data MapsServiceUsagePercentage (msum :: MapsServiceUsageMethod) = MapsServiceUsagePercentage
+  { usePercentage :: Bool, -- False by default
+    googlePercentage :: Maybe Int,
+    osrmPercentage :: Maybe Int,
+    mmiPercentage :: Maybe Int
+  }
+  deriving (Generic, FromJSON, ToJSON)
+
+mkMapsServiceUsage :: SMapsService msum -> MapsServiceUsagePercentage msum -> MapsServiceUsage msum
+mkMapsServiceUsage mapsService MapsServiceUsagePercentage {..} = MapsServiceUsage {..}
+
+mkMapsServiceUsagePercentage :: MapsServiceUsage msum -> MapsServiceUsagePercentage msum
+mkMapsServiceUsagePercentage MapsServiceUsage {..} = MapsServiceUsagePercentage {..}
+
+-- strict maps service for more type safety
+
+newtype SMapsService (msum :: MapsServiceUsageMethod) = SMapsService
+  { getStrictMapsService :: MapsService
+  }
+  deriving newtype (Show, Read, Eq, Ord, Generic, ToJSON, FromJSON, ToSchema, PrettyShow, PersistField, PersistFieldSql, FromField)
+
+instance HasSqlValueSyntax be String => HasSqlValueSyntax be (SMapsService msum) where
+  sqlValueSyntax = sqlValueSyntax . getStrictMapsService
+
+instance BeamSqlBackend be => B.HasSqlEqualityCheck be (SMapsService msum)
+
+instance Typeable msum => FromBackendRow Postgres (SMapsService msum)
+
+data MapsServiceUsageMethod
+  = GetDistances
+  | GetEstimatedPickupDistances
+  | GetRoutes
+  | GetPickupRoutes
+  | GetTripRoutes
+  | SnapToRoad
+  | GetPlaceName
+  | GetPlaceDetails
+  | AutoComplete
+  | GetDistancesForCancelRide
+
+genSingletons [''MapsServiceUsageMethod]
+
+-- TODO add some generic instance
+instance Show MapsServiceUsageMethod where
+  show = \case
+    GetDistances -> "getDistances"
+    GetEstimatedPickupDistances -> "getEstimatedPickupDistances"
+    GetRoutes -> "getRoutes"
+    GetPickupRoutes -> "getPickupRoutes"
+    GetTripRoutes -> "getTripRoutes"
+    SnapToRoad -> "snapToRoad"
+    GetPlaceName -> "getPlaceName"
+    GetPlaceDetails -> "getPlaceDetails"
+    AutoComplete -> "autoComplete"
+    GetDistancesForCancelRide -> "getDistancesForCancelRide"

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingStrategies #-}
 {-
   Copyright 2022-23, Juspay India Pvt Ltd
 
@@ -12,7 +11,6 @@
 
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-{-# LANGUAGE OverloadedLists #-}
 {-# OPTIONS_GHC -Wwarn=incomplete-record-updates #-}
 
 module Kernel.External.Payment.Interface.Types

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
@@ -11,6 +11,7 @@
 
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
+{-# LANGUAGE DerivingStrategies #-}
 {-# OPTIONS_GHC -Wwarn=incomplete-record-updates #-}
 
 module Kernel.External.Payment.Interface.Types

--- a/lib/mobility-core/src/Kernel/Randomizer.hs
+++ b/lib/mobility-core/src/Kernel/Randomizer.hs
@@ -16,7 +16,8 @@
 module Kernel.Randomizer where
 
 import Safe (at)
-import System.Random
+import System.Random hiding (random)
+import qualified Text.Show
 import Universum
 
 getRandomInRange :: (MonadIO m, Random a) => (a, a) -> m a
@@ -46,3 +47,75 @@ getRandomElement arr = do
   let len = length arr
   randNum <- getRandomInRange (0, len - 1)
   return $ toList arr `at` randNum
+
+-- get value from list using provided percentages
+
+data Percentage e = Percentage
+  { element :: e,
+    percentage :: Int
+  }
+
+data PercentagesResult e = PercentagesResult
+  { random :: Int,
+    pickedElement :: Either RangeError e,
+    ranges :: [PercentageRange e]
+  }
+  deriving (Show)
+
+data PercentageRange e = PercentageRange
+  { element :: e,
+    percentage :: Int,
+    range :: Range
+  }
+  deriving (Show)
+
+data Range = Range
+  { rangeFloor :: Int,
+    rangeCeil :: Int
+  }
+
+instance Show Range where
+  show range = show range.rangeFloor <> " < random <= " <> show range.rangeCeil
+
+-- RANGE_NOT_FOUND should never happen
+data RangeError
+  = EMPTY_ELEMENTS
+  | PERCENTAGE_LESS_THAN_0
+  | PERCENTAGE_MORE_THAN_100
+  | SUM_NOT_100
+  | RANGE_NOT_FOUND
+  deriving (Show, Eq)
+
+getRandomElementUsingPercentages :: MonadIO m => [Percentage e] -> m (PercentagesResult e)
+getRandomElementUsingPercentages percentages = do
+  random <- getRandomInRange (1, 100)
+  pure $ getRandomElementUsingPercentages' percentages random
+
+getRandomElementUsingPercentages' :: [Percentage e] -> Int -> PercentagesResult e
+getRandomElementUsingPercentages' percentages random
+  | null percentages = PercentagesResult {pickedElement = Left EMPTY_ELEMENTS, ranges = [], random}
+  | any (\p -> p.percentage < 0) percentages = PercentagesResult {pickedElement = Left PERCENTAGE_LESS_THAN_0, ranges = [], random}
+  | any (\p -> p.percentage > 100) percentages = PercentagesResult {pickedElement = Left PERCENTAGE_MORE_THAN_100, ranges = [], random}
+  | sum (map (.percentage) percentages) /= 100 = PercentagesResult {pickedElement = Left SUM_NOT_100, ranges = [], random}
+  | otherwise = do
+    let emptyResult = PercentagesResult {pickedElement = Left RANGE_NOT_FOUND, ranges = [], random}
+    foldl foldRange emptyResult percentages
+  where
+    foldRange :: PercentagesResult e -> Percentage e -> PercentagesResult e
+    foldRange result percentage = do
+      let range = maybe (Range 0 0) (.range) (listToMaybe result.ranges)
+          range' = Range {rangeFloor = range.rangeCeil, rangeCeil = range.rangeCeil + percentage.percentage}
+      let percentageRange' =
+            PercentageRange
+              { element = percentage.element,
+                percentage = percentage.percentage,
+                range = range'
+              }
+      let pickedElement' = case result.pickedElement of
+            Left err -> if range'.rangeFloor < random && random <= range'.rangeCeil then Right percentage.element else Left err
+            Right pickedElement -> Right pickedElement
+      PercentagesResult
+        { random,
+          pickedElement = pickedElement',
+          ranges = percentageRange' : result.ranges
+        }

--- a/lib/mobility-core/src/Kernel/Randomizer.hs
+++ b/lib/mobility-core/src/Kernel/Randomizer.hs
@@ -15,6 +15,7 @@
 
 module Kernel.Randomizer where
 
+import Kernel.Prelude (listToMaybe)
 import Safe (at)
 import System.Random hiding (random)
 import qualified Text.Show

--- a/lib/mobility-core/test/app/Main.hs
+++ b/lib/mobility-core/test/app/Main.hs
@@ -18,6 +18,7 @@ import APIExceptions
 import Centesimal
 import DistanceCalculation
 import EulerHS.Prelude
+import Randomizer
 import SignatureAuth
 import SlidingWindowLimiter
 import SnippetsCheck (snippetsCheckTests)
@@ -39,5 +40,6 @@ specs = return $ testGroup "Tests" [unitTests]
           slidingWindowLimiterTests,
           distanceCalculation,
           readVersionTests,
-          snippetsCheckTests
+          snippetsCheckTests,
+          randomizerTests
         ]

--- a/lib/mobility-core/test/src/Randomizer.hs
+++ b/lib/mobility-core/test/src/Randomizer.hs
@@ -1,0 +1,113 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Randomizer (randomizerTests) where
+
+import Kernel.Prelude
+import Kernel.Randomizer
+import Test.Tasty
+import Test.Tasty.HUnit
+
+randomizerTests :: TestTree
+randomizerTests =
+  testGroup
+    "getRandomElementUsingPercentages tests"
+    [ testGroup
+        "Should return error"
+        [ emptyElementsError,
+          percentageLessThan0Error,
+          percentageMoreThan100Error,
+          sumNot100Error,
+          rangeNotFoundError
+        ],
+      testGroup
+        "Should success"
+        [ successBoundaryCase,
+          successWithDifferentRandoms
+        ]
+    ]
+
+mkElements :: [Int] -> [Percentage Char]
+mkElements = zipWith (\element percentage -> Percentage {..}) ['a' ..]
+
+emptyElementsError :: TestTree
+emptyElementsError = do
+  let err = EMPTY_ELEMENTS
+  testCase ("Return error: " <> show err) $ do
+    let result = getRandomElementUsingPercentages' (mkElements []) 50
+    result.pickedElement @?= Left err
+
+percentageLessThan0Error :: TestTree
+percentageLessThan0Error = do
+  let err = PERCENTAGE_LESS_THAN_0
+  testCase ("Return error: " <> show err) $ do
+    let result = getRandomElementUsingPercentages' (mkElements [20, 90, -10]) 50
+    result.pickedElement @?= Left err
+
+percentageMoreThan100Error :: TestTree
+percentageMoreThan100Error = do
+  let err = PERCENTAGE_MORE_THAN_100
+  testCase ("Return error: " <> show err) $ do
+    let result = getRandomElementUsingPercentages' (mkElements [20, 110, 30]) 50
+    result.pickedElement @?= Left err
+
+sumNot100Error :: TestTree
+sumNot100Error = do
+  let err = SUM_NOT_100
+  testCase ("Return error: " <> show err) $ do
+    let result = getRandomElementUsingPercentages' (mkElements [20, 70, 9]) 50
+    result.pickedElement @?= Left err
+
+-- should be 1 <= random <= 100
+rangeNotFoundError :: TestTree
+rangeNotFoundError = do
+  let err = RANGE_NOT_FOUND
+  testCase ("Return error: " <> show err) $ do
+    let result1 = getRandomElementUsingPercentages' (mkElements [20, 70, 10]) 0
+    result1.pickedElement @?= Left err
+    let result2 = getRandomElementUsingPercentages' (mkElements [20, 70, 10]) 101
+    result2.pickedElement @?= Left err
+
+successBoundaryCase :: TestTree
+successBoundaryCase = do
+  testCase "Success boundary case: " $ do
+    let result1 = getRandomElementUsingPercentages' (mkElements [100]) 55
+    result1.pickedElement @?= Right 'a'
+    let randoms = [1 .. 100]
+    forM_ randoms $ \random -> do
+      let result2 = getRandomElementUsingPercentages' (mkElements [100, 0, 0]) random
+      result2.pickedElement @?= Right 'a'
+    let result3 = getRandomElementUsingPercentages' (mkElements [0, 100, 0]) 1
+    result3.pickedElement @?= Right 'b'
+    let result4 = getRandomElementUsingPercentages' (mkElements [0, 0, 100]) 12
+    result4.pickedElement @?= Right 'c'
+    let result5 = getRandomElementUsingPercentages' (mkElements [0, 0, 0, 0, 100, 0, 0]) 88
+    result5.pickedElement @?= Right 'e'
+
+successWithDifferentRandoms :: TestTree
+successWithDifferentRandoms = do
+  let percentages = mkElements [20, 70, 10]
+  testCase "Success with different randoms" $ do
+    let randoms1 = [1 .. 20]
+    forM_ randoms1 $ successTest percentages 'a'
+
+    let randoms2 = [21 .. 90]
+    forM_ randoms2 $ successTest percentages 'b'
+
+    let randoms3 = [91 .. 100]
+    forM_ randoms3 $ successTest percentages 'c'
+  where
+    successTest percentages el random = do
+      let result = getRandomElementUsingPercentages' percentages random
+      result.pickedElement @?= Right el


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Currently, we can completely switch between map providers based on DB config.

Along with the current capability, In order to test the accuracy of certain providers, we should have the ability to route certain percentage of the traffic to a map provider for each of the maps APIs used.

And as a follow up, we need to know the provider used corresponding to search request, estimate, ride request, booking for analytics purpose.

https://github.com/nammayatri/nammayatri/issues/1394
To be merged with https://github.com/nammayatri/nammayatri/pull/1639

### Additional Changes

- [x] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
tested locally, added unit tests


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
