### PR TITLE
backend/fix/#1784-added-cache-config-to-shared-kernel

### DIFF
--- a/lib/mobility-core/src/Kernel/Types/Cache.hs
+++ b/lib/mobility-core/src/Kernel/Types/Cache.hs
@@ -16,7 +16,18 @@
 module Kernel.Types.Cache where
 
 import Kernel.Prelude
+import Kernel.Storage.Hedis.Config
 import Kernel.Types.Time (Seconds)
+import Kernel.Utils.Dhall (FromDhall)
+
+newtype CacheConfig = CacheConfig
+  { configsExpTime :: Seconds
+  }
+  deriving (Generic, FromDhall)
+
+type HasCacheConfig r = HasField "cacheConfig" r CacheConfig
+
+type CacheFlow m r = (HasCacheConfig r, HedisFlow m r)
 
 class Cache a m where
   type CacheKey a


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
Shifted CacheConfig to Shared Kernel to reduce code repeatition.
