### PR TITLE
Mobility GHC927 Upgrade Final

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -213,16 +213,15 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1700111337,
+        "lastModified": 1700137322,
         "narHash": "sha256-QHWoOy48nH/V3uqPhIjQnCWqiIQVWuDOQlAe1KSjR84=",
         "owner": "nammayatri",
         "repo": "common",
-        "rev": "295b96a1cda479fbc28039df772efe1755d0340c",
+        "rev": "d5e3ed3f389cc5f5d3272912aa5207afba9436a0",
         "type": "github"
       },
       "original": {
         "owner": "nammayatri",
-        "ref": "Mobility-GHC927-disable-hls-fourmolu",
         "repo": "common",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -213,15 +213,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1699950488,
-        "narHash": "sha256-llyrSKHNFL1FptFykCelRjitl3x0b4JsSkQQyCKVZhU=",
+        "lastModified": 1700111337,
+        "narHash": "sha256-QHWoOy48nH/V3uqPhIjQnCWqiIQVWuDOQlAe1KSjR84=",
         "owner": "nammayatri",
         "repo": "common",
-        "rev": "0ae95ce0df4a0c6be221fdbd946f35e54e97ccf5",
+        "rev": "295b96a1cda479fbc28039df772efe1755d0340c",
         "type": "github"
       },
       "original": {
         "owner": "nammayatri",
+        "ref": "Mobility-GHC927-disable-hls-fourmolu",
         "repo": "common",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -184,16 +184,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1686306664,
-        "narHash": "sha256-qTQKX5tUUo6FCnhsDiW1QbWJkFaNnPpLX9ztgY4vjWk=",
-        "owner": "arjunkathuria",
+        "lastModified": 1699959073,
+        "narHash": "sha256-0Ovbd1CzgI4tSCTBe6z/7p8DpbajKyFlyS39hu4xpNY=",
+        "owner": "nammayatri",
         "repo": "clickhouse-haskell",
-        "rev": "f64d861934dcba0928a907605ab2c60d0a91aa4b",
+        "rev": "5314118b2635724b87f7993da9dc8446602bcd65",
         "type": "github"
       },
       "original": {
-        "owner": "arjunkathuria",
-        "ref": "Mobility/GHC-927-rebased",
+        "owner": "nammayatri",
         "repo": "clickhouse-haskell",
         "type": "github"
       }
@@ -214,16 +213,15 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1698621849,
-        "narHash": "sha256-/pd2eJNUUcEP6iKXyyrBJaqhQ79D4a+D98HJ3mNqjQ8=",
-        "owner": "arjunkathuria",
+        "lastModified": 1699950488,
+        "narHash": "sha256-llyrSKHNFL1FptFykCelRjitl3x0b4JsSkQQyCKVZhU=",
+        "owner": "nammayatri",
         "repo": "common",
-        "rev": "20580e2aa81b9adc45e6006472a8d73d062d8ff6",
+        "rev": "0ae95ce0df4a0c6be221fdbd946f35e54e97ccf5",
         "type": "github"
       },
       "original": {
-        "owner": "arjunkathuria",
-        "ref": "Mobility-GHC927-rebased-04",
+        "owner": "nammayatri",
         "repo": "common",
         "type": "github"
       }
@@ -244,16 +242,15 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1696580690,
-        "narHash": "sha256-6NsQIqnyYcOL1UVnNbptgssiQkU5ASVR4M0M4+MO7Jo=",
-        "owner": "arjunkathuria",
+        "lastModified": 1699950488,
+        "narHash": "sha256-llyrSKHNFL1FptFykCelRjitl3x0b4JsSkQQyCKVZhU=",
+        "owner": "nammayatri",
         "repo": "common",
-        "rev": "fb68c68fcbc6d87c346786befc203b4b71521f64",
+        "rev": "0ae95ce0df4a0c6be221fdbd946f35e54e97ccf5",
         "type": "github"
       },
       "original": {
-        "owner": "arjunkathuria",
-        "ref": "Mobility-GHC927-rebased-03",
+        "owner": "nammayatri",
         "repo": "common",
         "type": "github"
       }
@@ -391,16 +388,16 @@
         "tinylog": "tinylog"
       },
       "locked": {
-        "lastModified": 1699260708,
-        "narHash": "sha256-Rs434MZgNDQ+NPjty+bhv/yqCKu0AbRGZmw77uE1hIo=",
-        "owner": "arjunkathuria",
+        "lastModified": 1699954198,
+        "narHash": "sha256-o7t0pQtXBo+pEXk7lJ7J2Z07HEWFvlTwy7ZPoPn4Ptw=",
+        "owner": "juspay",
         "repo": "euler-hs",
-        "rev": "1835e721b2bbaf866e218375f88991d0dd232536",
+        "rev": "9492f18e5a36e163c3c55965254fe97f4524f7ac",
         "type": "github"
       },
       "original": {
-        "owner": "arjunkathuria",
-        "ref": "Mobility-GHC927-rebased-04",
+        "owner": "juspay",
+        "ref": "ag/open-source",
         "repo": "euler-hs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,36 +1,81 @@
 {
   "nodes": {
     "beam": {
-      "flake": false,
+      "inputs": {
+        "flake-parts": "flake-parts_6",
+        "haskell-flake": [
+          "euler-hs",
+          "sequelize",
+          "beam-mysql",
+          "haskell-flake"
+        ],
+        "nixpkgs": [
+          "euler-hs",
+          "sequelize",
+          "beam-mysql",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1676828369,
-        "narHash": "sha256-qCTCvYbrVJBr6dAWsvjt9cFiMiUDoh9U6L8Ykl3xtmU=",
-        "owner": "srid",
+        "lastModified": 1693307537,
+        "narHash": "sha256-BIq3ZjZQWQ0w3zWA19zGBggiVVfnOzR5d4b7De0oVZY=",
+        "owner": "arjunkathuria",
         "repo": "beam",
-        "rev": "d7031dcffafcab55850c9b3fd2561d3e279f1965",
+        "rev": "06bcc50997fdcfb87125bed252e888e5dd1e6d9c",
         "type": "github"
       },
       "original": {
-        "owner": "srid",
-        "ref": "ghc810",
+        "owner": "arjunkathuria",
+        "ref": "GHC-927-Upgrade",
         "repo": "beam",
         "type": "github"
       }
     },
     "beam-mysql": {
+      "inputs": {
+        "beam": "beam",
+        "bytestring-lexing": "bytestring-lexing",
+        "flake-parts": "flake-parts_7",
+        "haskell-flake": [
+          "euler-hs",
+          "sequelize",
+          "haskell-flake"
+        ],
+        "mysql-haskell": "mysql-haskell",
+        "nixpkgs": [
+          "euler-hs",
+          "sequelize",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1693308989,
+        "narHash": "sha256-3qyg/Uj3A+MTS494VH2lTBtOz9uptgm+V1M1bPFxTX0=",
+        "owner": "arjunkathuria",
+        "repo": "beam-mysql",
+        "rev": "2ef13d8ecdcd0959b8604b3106b2013baf2ad272",
+        "type": "github"
+      },
+      "original": {
+        "owner": "arjunkathuria",
+        "ref": "GHC-927",
+        "repo": "beam-mysql",
+        "type": "github"
+      }
+    },
+    "bytestring-lexing": {
       "flake": false,
       "locked": {
-        "lastModified": 1675165348,
-        "narHash": "sha256-sFOtfvAeFwIaMpMK8vD5usE71/jTHwDCdbf++h4jOqQ=",
+        "lastModified": 1596188445,
+        "narHash": "sha256-n/5kFb5msE8NPQZf6bsm8MQh0RGDoOx6EJXoji6FPMs=",
         "owner": "juspay",
-        "repo": "beam-mysql",
-        "rev": "b4dbc91276f6a8b5356633492f89bdac34ccd9a1",
+        "repo": "bytestring-lexing",
+        "rev": "0a46db1139011736687cb50bbd3877d223bcb737",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
-        "repo": "beam-mysql",
-        "rev": "b4dbc91276f6a8b5356633492f89bdac34ccd9a1",
+        "repo": "bytestring-lexing",
         "type": "github"
       }
     },
@@ -119,17 +164,16 @@
     "cereal": {
       "flake": false,
       "locked": {
-        "lastModified": 1668616659,
-        "narHash": "sha256-FkwxTJzY4A2CaGnQ+YBdEKZr+apEBK8Awcxrfp4uIvE=",
+        "lastModified": 1696234101,
+        "narHash": "sha256-dDUIny/9kZ0Bx/r/IPa9XRDcNT10XweR1uHqKx1CbAk=",
         "owner": "juspay",
         "repo": "cereal",
-        "rev": "213f145ccbd99e630ee832d2f5b22894c810d3cc",
+        "rev": "ee7fc69f499e86b8274906ba183b60f4f08457a6",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
         "repo": "cereal",
-        "rev": "213f145ccbd99e630ee832d2f5b22894c810d3cc",
         "type": "github"
       }
     },
@@ -140,15 +184,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1685470264,
-        "narHash": "sha256-WIrCW9tisY+S4uto3YhToSZPcxLtE82hOep9c5thHXU=",
-        "owner": "nammayatri",
+        "lastModified": 1686306664,
+        "narHash": "sha256-qTQKX5tUUo6FCnhsDiW1QbWJkFaNnPpLX9ztgY4vjWk=",
+        "owner": "arjunkathuria",
         "repo": "clickhouse-haskell",
-        "rev": "298bbaa9990ad34dd6836414a0d3e64387578774",
+        "rev": "f64d861934dcba0928a907605ab2c60d0a91aa4b",
         "type": "github"
       },
       "original": {
-        "owner": "nammayatri",
+        "owner": "arjunkathuria",
+        "ref": "Mobility/GHC-927-rebased",
         "repo": "clickhouse-haskell",
         "type": "github"
       }
@@ -169,15 +214,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1685470074,
-        "narHash": "sha256-0vdewKY4Vmx476Qg5qd2voyuL7ZssqOUlQeNJCuvs3Q=",
-        "owner": "nammayatri",
+        "lastModified": 1698621849,
+        "narHash": "sha256-/pd2eJNUUcEP6iKXyyrBJaqhQ79D4a+D98HJ3mNqjQ8=",
+        "owner": "arjunkathuria",
         "repo": "common",
-        "rev": "9b0393630068e688795bedd46c49df1a0bbc7c0a",
+        "rev": "20580e2aa81b9adc45e6006472a8d73d062d8ff6",
         "type": "github"
       },
       "original": {
-        "owner": "nammayatri",
+        "owner": "arjunkathuria",
+        "ref": "Mobility-GHC927-rebased-04",
         "repo": "common",
         "type": "github"
       }
@@ -198,15 +244,16 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1687365764,
-        "narHash": "sha256-T67Dr9TvZYfXEOuFPfdDnNKTc1Kqy6xyhFjXEXHu1Dc=",
-        "owner": "nammayatri",
+        "lastModified": 1696580690,
+        "narHash": "sha256-6NsQIqnyYcOL1UVnNbptgssiQkU5ASVR4M0M4+MO7Jo=",
+        "owner": "arjunkathuria",
         "repo": "common",
-        "rev": "5f16f3ebf64a4523eb8c1b20dadcb65cef5146ab",
+        "rev": "fb68c68fcbc6d87c346786befc203b4b71521f64",
         "type": "github"
       },
       "original": {
-        "owner": "nammayatri",
+        "owner": "arjunkathuria",
+        "ref": "Mobility-GHC927-rebased-03",
         "repo": "common",
         "type": "github"
       }
@@ -301,7 +348,6 @@
         "flake-parts": "flake-parts_3",
         "haskell-flake": [
           "euler-hs",
-          "common",
           "haskell-flake"
         ],
         "nixpkgs": "nixpkgs_11",
@@ -324,8 +370,6 @@
     },
     "euler-hs": {
       "inputs": {
-        "beam": "beam",
-        "beam-mysql": "beam-mysql",
         "cereal": "cereal",
         "common": "common_2",
         "euler-events-hs": "euler-events-hs",
@@ -335,31 +379,28 @@
           "flake-parts"
         ],
         "haskell-flake": [
-          "euler-hs",
-          "common",
           "haskell-flake"
         ],
         "hedis": "hedis",
         "juspay-extra": "juspay-extra",
-        "mysql-haskell": "mysql-haskell",
         "nixpkgs": [
-          "euler-hs",
-          "common",
           "nixpkgs"
         ],
-        "sequelize": "sequelize"
+        "sequelize": "sequelize",
+        "servant-mock": "servant-mock",
+        "tinylog": "tinylog"
       },
       "locked": {
-        "lastModified": 1697525861,
-        "narHash": "sha256-FDnmkTRc29RxOPbtLnCyHtKoUAKAXO5pEujkmIWjBs8=",
-        "owner": "juspay",
+        "lastModified": 1699260708,
+        "narHash": "sha256-Rs434MZgNDQ+NPjty+bhv/yqCKu0AbRGZmw77uE1hIo=",
+        "owner": "arjunkathuria",
         "repo": "euler-hs",
-        "rev": "a3ea4d2223dd10348821388219f0afdb076ee4d8",
+        "rev": "1835e721b2bbaf866e218375f88991d0dd232536",
         "type": "github"
       },
       "original": {
-        "owner": "juspay",
-        "ref": "ag/open-source",
+        "owner": "arjunkathuria",
+        "ref": "Mobility-GHC927-rebased-04",
         "repo": "euler-hs",
         "type": "github"
       }
@@ -521,6 +562,60 @@
     "flake-parts_6": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib_6"
+      },
+      "locked": {
+        "lastModified": 1690933134,
+        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_7": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_7"
+      },
+      "locked": {
+        "lastModified": 1690933134,
+        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_8": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_8"
+      },
+      "locked": {
+        "lastModified": 1690933134,
+        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_9": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_9"
       },
       "locked": {
         "lastModified": 1683560683,
@@ -807,7 +902,6 @@
         "flake-parts": "flake-parts_5",
         "haskell-flake": [
           "euler-hs",
-          "common",
           "haskell-flake"
         ],
         "nixpkgs": "nixpkgs_13"
@@ -889,19 +983,34 @@
       }
     },
     "mysql-haskell": {
-      "flake": false,
+      "inputs": {
+        "flake-parts": "flake-parts_8",
+        "haskell-flake": [
+          "euler-hs",
+          "sequelize",
+          "beam-mysql",
+          "haskell-flake"
+        ],
+        "nixpkgs": [
+          "euler-hs",
+          "sequelize",
+          "beam-mysql",
+          "nixpkgs"
+        ],
+        "word24": "word24"
+      },
       "locked": {
-        "lastModified": 1594736429,
-        "narHash": "sha256-mxIaWkfyrF0FhEK2WLhyPiIiGjKlG2kUn78E+GDAGAw=",
-        "owner": "juspay",
+        "lastModified": 1692868544,
+        "narHash": "sha256-UY9HRnqWXv5Ud6pfBa/fPNwjauDYpgzJoLcQb4NuH7I=",
+        "owner": "arjunkathuria",
         "repo": "mysql-haskell",
-        "rev": "788022d65538db422b02ecc0be138b862d2e5cee",
+        "rev": "2f4861667d19e84474700f32922c97af94f5dfc4",
         "type": "github"
       },
       "original": {
-        "owner": "juspay",
+        "owner": "arjunkathuria",
+        "ref": "GHC-927",
         "repo": "mysql-haskell",
-        "rev": "788022d65538db422b02ecc0be138b862d2e5cee",
         "type": "github"
       }
     },
@@ -1131,6 +1240,60 @@
     "nixpkgs-lib_6": {
       "locked": {
         "dir": "lib",
+        "lastModified": 1690881714,
+        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_7": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1690881714,
+        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_8": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1690881714,
+        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_9": {
+      "locked": {
+        "dir": "lib",
         "lastModified": 1682879489,
         "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
         "owner": "NixOS",
@@ -1340,11 +1503,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1681358109,
-        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "lastModified": 1696261572,
+        "narHash": "sha256-s8TtSYJ1LBpuITXjbPLUPyxzAKw35LhETcajJjCS5f0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "rev": "0c7ffbc66e6d78c50c38e717ec91a2a14e0622fb",
         "type": "github"
       },
       "original": {
@@ -1420,11 +1583,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1681358109,
-        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "lastModified": 1696261572,
+        "narHash": "sha256-s8TtSYJ1LBpuITXjbPLUPyxzAKw35LhETcajJjCS5f0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "rev": "0c7ffbc66e6d78c50c38e717ec91a2a14e0622fb",
         "type": "github"
       },
       "original": {
@@ -1583,11 +1746,11 @@
     },
     "process-compose-flake": {
       "locked": {
-        "lastModified": 1680797953,
-        "narHash": "sha256-lFYbfId1IX6jh/wUf+gt3LyvE9HblS4hcBQcougSzX0=",
+        "lastModified": 1687298948,
+        "narHash": "sha256-7Lu4/odCkkwrzR8Mo+3D+URv4oLap8WWLESzi/75eb0=",
         "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
-        "rev": "aee1b8d126a5efe5945513eb2fb343f3d68dca4b",
+        "rev": "5bdb90b85642901cf9a5dccfe8c907091c261604",
         "type": "github"
       },
       "original": {
@@ -1638,7 +1801,7 @@
     },
     "prometheus-haskell_2": {
       "inputs": {
-        "flake-parts": "flake-parts_6",
+        "flake-parts": "flake-parts_9",
         "haskell-flake": [
           "common",
           "haskell-flake"
@@ -1665,24 +1828,63 @@
         "clickhouse-haskell": "clickhouse-haskell",
         "common": "common",
         "euler-hs": "euler-hs",
+        "haskell-flake": [
+          "common",
+          "haskell-flake"
+        ],
+        "nixpkgs": [
+          "common",
+          "nixpkgs"
+        ],
         "passetto-hs": "passetto-hs",
         "prometheus-haskell": "prometheus-haskell_2"
       }
     },
     "sequelize": {
-      "flake": false,
+      "inputs": {
+        "beam-mysql": "beam-mysql",
+        "flake-parts": [
+          "euler-hs",
+          "flake-parts"
+        ],
+        "haskell-flake": [
+          "euler-hs",
+          "haskell-flake"
+        ],
+        "nixpkgs": [
+          "euler-hs",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1688647938,
-        "narHash": "sha256-F7nixhDpXNRrpgxRH3xtnN+FkB2HS44VMrnoq1VfBnI=",
+        "lastModified": 1696055637,
+        "narHash": "sha256-RVlpKevWjt9pB9Ia61+ILFcbjB8omiRA6zehmPb6FHg=",
         "owner": "juspay",
         "repo": "haskell-sequelize",
-        "rev": "dc01b0f9e6ba5a51dd8f9d0744a549dc9c0ba244",
+        "rev": "991064c0b9b5f5cf691b19d53ac6b0c9109a2dff",
         "type": "github"
       },
       "original": {
         "owner": "juspay",
+        "ref": "beckn-compatible",
         "repo": "haskell-sequelize",
-        "rev": "dc01b0f9e6ba5a51dd8f9d0744a549dc9c0ba244",
+        "type": "github"
+      }
+    },
+    "servant-mock": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672315259,
+        "narHash": "sha256-J7Lsa3zI1Z05Gtf5m1x4yRE5vRnuhZLWeUShtrhsPbk=",
+        "owner": "arjunkathuria",
+        "repo": "servant-mock",
+        "rev": "17e90cb831820a30b3215d4f164cf8268607891e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "arjunkathuria",
+        "repo": "servant-mock",
+        "rev": "17e90cb831820a30b3215d4f164cf8268607891e",
         "type": "github"
       }
     },
@@ -1714,6 +1916,22 @@
         "owner": "nix-systems",
         "repo": "default",
         "type": "github"
+      }
+    },
+    "tinylog": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669960992,
+        "narHash": "sha256-o0WEbygbbfIYPonyY6ui1HcbaJcFdngjBhnjWbe65zs=",
+        "rev": "08d3b6066cd2f883e183b7cd01809d1711092d33",
+        "revCount": 78,
+        "type": "git",
+        "url": "https://gitlab.com/arjunkathuria/tinylog.git"
+      },
+      "original": {
+        "rev": "08d3b6066cd2f883e183b7cd01809d1711092d33",
+        "type": "git",
+        "url": "https://gitlab.com/arjunkathuria/tinylog.git"
       }
     },
     "treefmt-nix": {
@@ -1749,6 +1967,22 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "word24": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647587255,
+        "narHash": "sha256-S37S10sJ45BulvpqJzlhX/J4hY7cW5jLM9nP4xAftac=",
+        "owner": "winterland1989",
+        "repo": "word24",
+        "rev": "445f791e35ddc8098f05879dbcd07c41b115cb39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "winterland1989",
+        "repo": "word24",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,7 @@
           };
           autoWire = [ "packages" "checks" ];
         };
+        process-compose = { };
         packages.default = self'.packages.mobility-core;
         devShells.default = pkgs.mkShell {
           # cf. https://haskell.flake.page/devshell#composing-devshells

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,7 @@
               jailbreak = true;
             };
             clickhouse-haskell.jailbreak = true;
+            generic-deriving.check = false;
           };
           autoWire = [ "packages" "checks" ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,28 @@
 {
   inputs = {
-    common.url = "github:nammayatri/common";
+    # Replace the url with upstream when 9.2 changes merge there.
+    # common.url = "github:nammayatri/common";
+    common.url = "github:arjunkathuria/common/Mobility-GHC927-rebased-04";
+    nixpkgs.follows = "common/nixpkgs";
+    haskell-flake.follows = "common/haskell-flake";
 
     passetto-hs.url = "github:juspay/passetto/bb92cf1dd9699662d2a7bb96cd6a6aed6f20e8ff";
     passetto-hs.flake = false;
 
-    clickhouse-haskell.url = "github:nammayatri/clickhouse-haskell";
+    # Replace the url with upstream when 9.2 changes merge there.
+    # clickhouse-haskell.url = "github:nammayatri/clickhouse-haskell";
+    clickhouse-haskell.url = "github:arjunkathuria/clickhouse-haskell/Mobility\/GHC-927-rebased";
     clickhouse-haskell.inputs.common.follows = "common";
     prometheus-haskell.url = "github:juspay/prometheus-haskell/more-proc-metrics";
     prometheus-haskell.inputs.haskell-flake.follows = "common/haskell-flake";
 
-    euler-hs.url = "github:juspay/euler-hs/ag/open-source";
+    # Replace the url with upstream when 9.2 changes merge there.
+    # euler-hs.url = "github:juspay/euler-hs/ag/open-source";
+    euler-hs = {
+      url = "github:arjunkathuria/euler-hs/Mobility-GHC927-rebased-04";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.haskell-flake.follows = "haskell-flake";
+    };
   };
   outputs = inputs:
     inputs.common.lib.mkFlake { inherit inputs; } {
@@ -63,4 +75,3 @@
       };
     };
 }
-

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    common.url = "github:nammayatri/common/Mobility-GHC927-disable-hls-fourmolu";
+    common.url = "github:nammayatri/common";
     nixpkgs.follows = "common/nixpkgs";
     haskell-flake.follows = "common/haskell-flake";
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,25 +1,19 @@
 {
   inputs = {
-    # Replace the url with upstream when 9.2 changes merge there.
-    # common.url = "github:nammayatri/common";
-    common.url = "github:arjunkathuria/common/Mobility-GHC927-rebased-04";
+    common.url = "github:nammayatri/common";
     nixpkgs.follows = "common/nixpkgs";
     haskell-flake.follows = "common/haskell-flake";
 
     passetto-hs.url = "github:juspay/passetto/bb92cf1dd9699662d2a7bb96cd6a6aed6f20e8ff";
     passetto-hs.flake = false;
 
-    # Replace the url with upstream when 9.2 changes merge there.
-    # clickhouse-haskell.url = "github:nammayatri/clickhouse-haskell";
-    clickhouse-haskell.url = "github:arjunkathuria/clickhouse-haskell/Mobility\/GHC-927-rebased";
+    clickhouse-haskell.url = "github:nammayatri/clickhouse-haskell";
     clickhouse-haskell.inputs.common.follows = "common";
     prometheus-haskell.url = "github:juspay/prometheus-haskell/more-proc-metrics";
     prometheus-haskell.inputs.haskell-flake.follows = "common/haskell-flake";
 
-    # Replace the url with upstream when 9.2 changes merge there.
-    # euler-hs.url = "github:juspay/euler-hs/ag/open-source";
     euler-hs = {
-      url = "github:arjunkathuria/euler-hs/Mobility-GHC927-rebased-04";
+      url = "github:juspay/euler-hs/ag/open-source";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.haskell-flake.follows = "haskell-flake";
     };

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    common.url = "github:nammayatri/common";
+    common.url = "github:nammayatri/common/Mobility-GHC927-disable-hls-fourmolu";
     nixpkgs.follows = "common/nixpkgs";
     haskell-flake.follows = "common/haskell-flake";
 

--- a/lib/mobility-core/mobility-core.cabal
+++ b/lib/mobility-core/mobility-core.cabal
@@ -447,8 +447,6 @@ library
     , wai-middleware-prometheus
     , warp
   default-language: Haskell2010
-  if os(darwin)
-    ghc-options: -fwhole-archive-hs-libs
 
 test-suite mobility-core-tests
   type: exitcode-stdio-1.0
@@ -602,5 +600,3 @@ test-suite mobility-core-tests
     , wai-middleware-prometheus
     , warp
   default-language: Haskell2010
-  if os(darwin)
-    ghc-options: -fwhole-archive-hs-libs

--- a/lib/mobility-core/mobility-core.cabal
+++ b/lib/mobility-core/mobility-core.cabal
@@ -447,6 +447,8 @@ library
     , wai-middleware-prometheus
     , warp
   default-language: Haskell2010
+  if os(darwin)
+    ghc-options: -fwhole-archive-hs-libs
 
 test-suite mobility-core-tests
   type: exitcode-stdio-1.0
@@ -600,3 +602,5 @@ test-suite mobility-core-tests
     , wai-middleware-prometheus
     , warp
   default-language: Haskell2010
+  if os(darwin)
+    ghc-options: -fwhole-archive-hs-libs

--- a/lib/mobility-core/mobility-core.cabal
+++ b/lib/mobility-core/mobility-core.cabal
@@ -367,7 +367,7 @@ library
     , cryptonite
     , data-default-class
     , deriving-aeson
-    , dhall <=1.35.0
+    , dhall
     , double-conversion
     , either
     , esqueleto
@@ -435,7 +435,7 @@ library
     , time
     , tinylog
     , transformers
-    , universum <1.8
+    , universum
     , unix
     , unliftio
     , unliftio-core
@@ -519,7 +519,7 @@ test-suite mobility-core-tests
     , cryptonite
     , data-default-class
     , deriving-aeson
-    , dhall <=1.35.0
+    , dhall
     , double-conversion
     , either
     , esqueleto
@@ -588,7 +588,7 @@ test-suite mobility-core-tests
     , time
     , tinylog
     , transformers
-    , universum <1.8
+    , universum
     , unix
     , unliftio
     , unliftio-core

--- a/lib/mobility-core/mobility-core.cabal
+++ b/lib/mobility-core/mobility-core.cabal
@@ -346,7 +346,7 @@ library
       BlockArguments
       TypeSynonymInstances
       UndecidableInstances
-  ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -Wcompat -Widentities -fhide-source-paths -Werror -fplugin=RecordDotPreprocessor
+  ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -Wcompat -Widentities -fhide-source-paths -Werror -fplugin=RecordDotPreprocessor -Wwarn=ambiguous-fields
   build-depends:
       aeson
     , aeson-casing
@@ -376,6 +376,7 @@ library
     , extra
     , fast-logger
     , fmt
+    , formatting
     , generic-lens
     , geojson
     , hedis
@@ -420,6 +421,8 @@ library
     , servant-client
     , servant-client-core
     , servant-multipart
+    , servant-multipart-api
+    , servant-multipart-client
     , servant-openapi3
     , servant-server
     , stm
@@ -495,7 +498,7 @@ test-suite mobility-core-tests
       BlockArguments
       TypeSynonymInstances
       UndecidableInstances
-  ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -Wcompat -Widentities -fhide-source-paths -Werror -fplugin=RecordDotPreprocessor
+  ghc-options: -fwrite-ide-info -hiedir=.hie -Wall -Wcompat -Widentities -fhide-source-paths -Werror -fplugin=RecordDotPreprocessor -Wwarn=ambiguous-fields
   build-depends:
       aeson
     , aeson-casing
@@ -525,6 +528,7 @@ test-suite mobility-core-tests
     , extra
     , fast-logger
     , fmt
+    , formatting
     , generic-lens
     , geojson
     , hedis
@@ -570,6 +574,8 @@ test-suite mobility-core-tests
     , servant-client
     , servant-client-core
     , servant-multipart
+    , servant-multipart-api
+    , servant-multipart-client
     , servant-openapi3
     , servant-server
     , stm

--- a/lib/mobility-core/package.yaml
+++ b/lib/mobility-core/package.yaml
@@ -155,6 +155,7 @@ ghc-options:
   - -fhide-source-paths
   - -Werror
   - -fplugin=RecordDotPreprocessor
+  - -Wwarn=ambiguous-fields
 
 library:
   source-dirs:

--- a/lib/mobility-core/package.yaml
+++ b/lib/mobility-core/package.yaml
@@ -138,6 +138,8 @@ dependencies:
   - tinylog
   - wai-app-static
   - servant-multipart
+  - servant-multipart-api
+  - servant-multipart-client
   - clickhouse-haskell
   - beam-postgres
   - beam-core

--- a/lib/mobility-core/package.yaml
+++ b/lib/mobility-core/package.yaml
@@ -62,6 +62,7 @@ dependencies:
   - double-conversion
   - exceptions
   - euler-hs
+  - formatting
   - hex-text
   - hspec
   - http-api-data

--- a/lib/mobility-core/package.yaml
+++ b/lib/mobility-core/package.yaml
@@ -102,7 +102,7 @@ dependencies:
   - unordered-containers
   - geojson
   - safe-money
-  - dhall <= 1.35.0
+  - dhall
   - tasty
   - tasty-hunit
   - either
@@ -120,7 +120,7 @@ dependencies:
   - monad-logger
   - unliftio-core
   - resource-pool
-  - universum < 1.8
+  - universum
   - scientific
   - vector
   - unliftio

--- a/lib/mobility-core/src/Kernel/Beam/Types.hs
+++ b/lib/mobility-core/src/Kernel/Beam/Types.hs
@@ -6,7 +6,7 @@
 module Kernel.Beam.Types where
 
 import qualified Database.Beam.Postgres as BP
-import EulerHS.Prelude hiding (getOption)
+import EulerHS.Prelude
 import EulerHS.Types (DBConfig, OptionEntity)
 import Kernel.Streaming.Kafka.Producer.Types
 import qualified Kernel.Types.Common as KTC

--- a/lib/mobility-core/src/Kernel/External/Call/Exotel/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Call/Exotel/Types.hs
@@ -31,13 +31,12 @@ import Data.Aeson.TH
 import Data.Aeson.Types
 import qualified Data.Text as T
 import Kernel.External.Encryption (DbHashable)
-import Kernel.Mock.Utils (decodeJSONText)
 import Kernel.Prelude hiding (showBaseUrl)
 import Kernel.Storage.Esqueleto (derivePersistField)
 import Kernel.Types.Beckn.Ack (AckResponse)
 import Kernel.Utils.JSON
-import Kernel.Utils.Text (decodeFromText)
 import Kernel.Utils.TH
+import Kernel.Utils.Text (decodeFromText)
 import Servant.Client
 import Web.FormUrlEncoded (ToForm, toForm)
 import Web.Internal.HttpApiData

--- a/lib/mobility-core/src/Kernel/External/Call/Exotel/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Call/Exotel/Types.hs
@@ -36,6 +36,7 @@ import Kernel.Prelude hiding (showBaseUrl)
 import Kernel.Storage.Esqueleto (derivePersistField)
 import Kernel.Types.Beckn.Ack (AckResponse)
 import Kernel.Utils.JSON
+import Kernel.Utils.Text (decodeFromText)
 import Kernel.Utils.TH
 import Servant.Client
 import Web.FormUrlEncoded (ToForm, toForm)
@@ -283,7 +284,7 @@ instance FromJSON a => FromJSON (ExotelCallCallbackReq a) where
 
 parseCustomField :: FromJSON a => Value -> Text -> Parser a
 parseCustomField v txt = do
-  case decodeJSONText txt of
+  case decodeFromText txt of
     Just exoAttch -> return exoAttch
     Nothing -> typeMismatch "CustomField" v
 

--- a/lib/mobility-core/src/Kernel/External/Maps/Interface/MMI.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Interface/MMI.hs
@@ -23,7 +23,7 @@ module Kernel.External.Maps.Interface.MMI
   )
 where
 
-import Data.List ((!!))
+import Data.List.Extra ((!!))
 import qualified Data.List.Extra as List
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe

--- a/lib/mobility-core/src/Kernel/External/Notification/Interface/PayTM.hs
+++ b/lib/mobility-core/src/Kernel/External/Notification/Interface/PayTM.hs
@@ -1,6 +1,7 @@
 module Kernel.External.Notification.Interface.PayTM where
 
 import Data.Aeson
+import qualified Data.Aeson.KeyMap as AKM
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T hiding (map)
 import qualified Kernel.External.Notification.Interface.Types as Interface
@@ -42,5 +43,5 @@ notifyPerson config req = do
   where
     toHashMap :: (ToJSON a) => a -> HM.HashMap Text Value
     toHashMap val = case toJSON val of
-      Object obj -> obj
+      Object obj -> AKM.toHashMapText obj
       _ -> HM.empty

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
@@ -11,6 +11,7 @@
 
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
+{-# OPTIONS_GHC -Wwarn=incomplete-uni-patterns #-}
 
 module Kernel.External.Payment.Interface.Juspay
   ( module Reexport,

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
@@ -13,6 +13,7 @@
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE OverloadedLists #-}
+{-# OPTIONS_GHC -Wwarn=incomplete-record-updates #-}
 
 module Kernel.External.Payment.Interface.Types
   ( module Kernel.External.Payment.Interface.Types,

--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/Auth.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/Auth.hs
@@ -14,8 +14,7 @@
 
 module Kernel.External.Verification.Idfy.Auth where
 
-import qualified Data.HashMap.Internal as HMap
-import qualified Data.Text as T
+import qualified Data.HashMap.Strict as HMS
 import EulerHS.Prelude
 import Kernel.External.Encryption
 import Kernel.External.Verification.Idfy.Config
@@ -40,10 +39,10 @@ verifyAuth cfg authSecret = do
   cfgSecret <- decrypt cfg.secret
   unless (authSecret == Just cfgSecret) $ throwError (InvalidRequest "INVALID_AUTHORIZATION_HEADER")
 
-prepareIdfyHttpManager :: Int -> HMap.HashMap T.Text Http.ManagerSettings
+prepareIdfyHttpManager :: Int -> HashMap Text Http.ManagerSettings
 prepareIdfyHttpManager timeout =
-  HMap.singleton (T.pack idfyHttpManagerKey) $
+  HMS.singleton idfyHttpManagerKey $
     Http.tlsManagerSettings {Http.managerResponseTimeout = Http.responseTimeoutMicro (timeout * 1000)}
 
-idfyHttpManagerKey :: String
+idfyHttpManagerKey :: Text
 idfyHttpManagerKey = "idfy-http-manager"

--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/Client.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/Client.hs
@@ -211,4 +211,4 @@ getTask apiKey accountId url request_id = callIdfyAPI url task "getTask" getTask
         request_id
 
 callIdfyAPI :: CallAPI env api res
-callIdfyAPI = callApiUnwrappingApiError (identity @IdfyError) (Just $ T.ManagerSelector $ DT.pack idfyHttpManagerKey) (Just "IDFY_ERROR")
+callIdfyAPI = callApiUnwrappingApiError (identity @IdfyError) (Just $ T.ManagerSelector idfyHttpManagerKey) (Just "IDFY_ERROR")

--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/Client.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/Client.hs
@@ -27,9 +27,6 @@ module Kernel.External.Verification.Idfy.Client
   )
 where
 
--- import qualified Data.Text as T
-
-import qualified Data.Text as DT
 import EulerHS.Prelude
 import qualified EulerHS.Types as T
 import Kernel.External.Verification.Idfy.Auth

--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/WebhookHandler.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/WebhookHandler.hs
@@ -15,6 +15,7 @@
 module Kernel.External.Verification.Idfy.WebhookHandler where
 
 import Data.Aeson.Types as DAT
+import Data.Maybe (listToMaybe)
 import EulerHS.Prelude
 import Kernel.External.Verification.Idfy.Auth
 import Kernel.External.Verification.Idfy.Config

--- a/lib/mobility-core/src/Kernel/Prelude.hs
+++ b/lib/mobility-core/src/Kernel/Prelude.hs
@@ -50,7 +50,7 @@ import qualified Servant.Client as Servant
 import Text.Read as E (readMaybe)
 import Universum.Debug as E
 import Universum.Print as E
-import Universum.String.Conversion as E
+import Universum.String.Conversion as E hiding (readMaybe)
 import Prelude as E hiding (error, id, log, print, putStr, putStrLn, show, undefined)
 
 foldWIndex :: (Integer -> acc -> a -> acc) -> acc -> [a] -> acc

--- a/lib/mobility-core/src/Kernel/Prelude/OrphanInstances.hs
+++ b/lib/mobility-core/src/Kernel/Prelude/OrphanInstances.hs
@@ -16,12 +16,12 @@
 
 module Kernel.Prelude.OrphanInstances where
 
-import EulerHS.Language ()
-import GHC.Generics
+import Control.Lens (At, Index, IxValue, Ixed, Lens', at, coerced, ix)
 import qualified Data.OpenApi as DS
-import Control.Lens (at, ix, Index, IxValue, At, Ixed, coerced, Lens')
 import Data.Text (Text)
+import EulerHS.Language ()
 import EulerHS.Prelude ((.))
+import GHC.Generics ()
 
 -- deriving instance Generic (a,b,c,d,e,f,g,h) -- uncomment this when remove EulerHS
 -- deriving instance Generic (a, b, c, d, e, f, g, h, i)
@@ -66,8 +66,10 @@ deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r,
 
 -- Index and IxValue Type Family instances for SecurityDefinitions
 type instance Index DS.SecurityDefinitions = Text
+
 type instance IxValue DS.SecurityDefinitions = DS.SecurityScheme
 
 -- Ixed and At Type-Class instances for SecurityDefinitions
-instance Ixed DS.SecurityDefinitions where ix n = (coerced :: Lens' DS.SecurityDefinitions (DS.Definitions DS.SecurityScheme)). ix n
-instance At   DS.SecurityDefinitions where at n = (coerced :: Lens' DS.SecurityDefinitions (DS.Definitions DS.SecurityScheme)). at n
+instance Ixed DS.SecurityDefinitions where ix n = (coerced :: Lens' DS.SecurityDefinitions (DS.Definitions DS.SecurityScheme)) . ix n
+
+instance At DS.SecurityDefinitions where at n = (coerced :: Lens' DS.SecurityDefinitions (DS.Definitions DS.SecurityScheme)) . at n

--- a/lib/mobility-core/src/Kernel/Prelude/OrphanInstances.hs
+++ b/lib/mobility-core/src/Kernel/Prelude/OrphanInstances.hs
@@ -17,6 +17,11 @@
 module Kernel.Prelude.OrphanInstances where
 
 import EulerHS.Language ()
+import GHC.Generics
+import qualified Data.OpenApi as DS
+import Control.Lens (at, ix, Index, IxValue, At, Ixed, coerced, Lens')
+import Data.Text (Text)
+import EulerHS.Prelude ((.))
 
 -- deriving instance Generic (a,b,c,d,e,f,g,h) -- uncomment this when remove EulerHS
 -- deriving instance Generic (a, b, c, d, e, f, g, h, i)
@@ -56,4 +61,13 @@ deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r,
 deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y)
 
 deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z)
+
 -}
+
+-- Index and IxValue Type Family instances for SecurityDefinitions
+type instance Index DS.SecurityDefinitions = Text
+type instance IxValue DS.SecurityDefinitions = DS.SecurityScheme
+
+-- Ixed and At Type-Class instances for SecurityDefinitions
+instance Ixed DS.SecurityDefinitions where ix n = (coerced :: Lens' DS.SecurityDefinitions (DS.Definitions DS.SecurityScheme)). ix n
+instance At   DS.SecurityDefinitions where at n = (coerced :: Lens' DS.SecurityDefinitions (DS.Definitions DS.SecurityScheme)). at n

--- a/lib/mobility-core/src/Kernel/Prelude/OrphanInstances.hs
+++ b/lib/mobility-core/src/Kernel/Prelude/OrphanInstances.hs
@@ -23,17 +23,17 @@ import EulerHS.Language ()
 
 {-
 
-deriving instance Generic (a, b, c, d, e, f, g, h, i, j)
+-- deriving instance Generic (a, b, c, d, e, f, g, h, i, j)
 
-deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k)
+-- deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k)
 
-deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k, l)
+-- deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k, l)
 
 -- deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k, l, m)
 
-deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k, l, m, n)
+-- deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k, l, m, n)
 
-deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)
+-- deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)
 
 deriving instance Generic (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)
 

--- a/lib/mobility-core/src/Kernel/Product/Validation/Context.hs
+++ b/lib/mobility-core/src/Kernel/Product/Validation/Context.hs
@@ -14,8 +14,9 @@
 
 module Kernel.Product.Validation.Context where
 
+import Control.Lens (view)
 import qualified EulerHS.Language as L
-import EulerHS.Prelude
+import EulerHS.Prelude hiding (view)
 import qualified Kernel.Types.Beckn.Context as CoreContext
 import Kernel.Types.Common
 import Kernel.Types.Error

--- a/lib/mobility-core/src/Kernel/Randomizer.hs
+++ b/lib/mobility-core/src/Kernel/Randomizer.hs
@@ -11,7 +11,6 @@
 
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-
 {-# OPTIONS_GHC -Wwarn=incomplete-uni-patterns #-}
 
 module Kernel.Randomizer where

--- a/lib/mobility-core/src/Kernel/Randomizer.hs
+++ b/lib/mobility-core/src/Kernel/Randomizer.hs
@@ -12,6 +12,8 @@
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 
+{-# OPTIONS_GHC -Wwarn=incomplete-uni-patterns #-}
+
 module Kernel.Randomizer where
 
 import Safe (at)

--- a/lib/mobility-core/src/Kernel/ServantMultipart.hs
+++ b/lib/mobility-core/src/Kernel/ServantMultipart.hs
@@ -15,6 +15,8 @@
 
 module Kernel.ServantMultipart
   ( module Servant.Multipart,
+    module Servant.Multipart.API,
+    module Servant.Multipart.Client
   )
 where
 
@@ -22,6 +24,8 @@ import Kernel.Prelude
 import Kernel.Utils.Monitoring.Prometheus.Servant
 import Servant hiding (ResponseHeader (..))
 import Servant.Multipart
+import Servant.Multipart.API
+import Servant.Multipart.Client
 import qualified Servant.OpenApi as S
 
 instance

--- a/lib/mobility-core/src/Kernel/ServantMultipart.hs
+++ b/lib/mobility-core/src/Kernel/ServantMultipart.hs
@@ -16,7 +16,7 @@
 module Kernel.ServantMultipart
   ( module Servant.Multipart,
     module Servant.Multipart.API,
-    module Servant.Multipart.Client
+    module Servant.Multipart.Client,
   )
 where
 

--- a/lib/mobility-core/src/Kernel/Storage/Esqueleto/Queries.hs
+++ b/lib/mobility-core/src/Kernel/Storage/Esqueleto/Queries.hs
@@ -79,7 +79,6 @@ import Database.Esqueleto.Experimental as EsqExport hiding
   )
 import qualified Database.Esqueleto.Experimental as Esq
 import qualified Database.Esqueleto.Internal.Internal as Esq
-import Database.Persist.Class (OnlyOneUniqueKey, onlyUniqueP)
 import Kernel.Prelude
 import Kernel.Storage.Esqueleto.Class
 import Kernel.Storage.Esqueleto.DTypeBuilder

--- a/lib/mobility-core/src/Kernel/Storage/Esqueleto/Queries.hs
+++ b/lib/mobility-core/src/Kernel/Storage/Esqueleto/Queries.hs
@@ -134,6 +134,7 @@ findAllInternal q = liftToBuilder . runTransaction . SelectSqlDB . SqlDB $ lift 
 create ::
   ( PersistEntity t,
     PersistEntityBackend t ~ SqlBackend,
+    SafeToInsert t,
     ToTType t a
   ) =>
   a ->
@@ -144,7 +145,8 @@ create q = do
 
 create' ::
   ( PersistEntity t,
-    PersistEntityBackend t ~ SqlBackend
+    PersistEntityBackend t ~ SqlBackend,
+    SafeToInsert t
   ) =>
   t ->
   FullEntitySqlDB ()
@@ -154,6 +156,7 @@ create' q = do
 createMany ::
   ( PersistEntity t,
     PersistEntityBackend t ~ SqlBackend,
+    SafeToInsert t,
     ToTType t a
   ) =>
   [a] ->
@@ -164,7 +167,8 @@ createMany q = do
 
 createMany' ::
   ( PersistEntity t,
-    PersistEntityBackend t ~ SqlBackend
+    PersistEntityBackend t ~ SqlBackend,
+    SafeToInsert t
   ) =>
   [t] ->
   FullEntitySqlDB ()
@@ -174,6 +178,7 @@ createMany' q = do
 createUnique ::
   ( PersistEntity t,
     PersistEntityBackend t ~ SqlBackend,
+    SafeToInsert t,
     ToTType t a
   ) =>
   a ->
@@ -184,7 +189,8 @@ createUnique q = do
 
 createUnique' ::
   ( PersistEntity t,
-    PersistEntityBackend t ~ SqlBackend
+    PersistEntityBackend t ~ SqlBackend,
+    SafeToInsert t
   ) =>
   t ->
   FullEntitySqlDB (Maybe (Key t))
@@ -284,6 +290,7 @@ repsert' k v = do
 upsert ::
   ( OnlyOneUniqueKey t,
     PersistEntityBackend t ~ SqlBackend,
+    SafeToInsert t,
     ToTType t a
   ) =>
   a ->
@@ -295,7 +302,8 @@ upsert r u = do
 
 upsert' ::
   ( OnlyOneUniqueKey t,
-    PersistEntityBackend t ~ SqlBackend
+    PersistEntityBackend t ~ SqlBackend,
+    SafeToInsert t
   ) =>
   t ->
   [SqlExpr (Entity t) -> SqlExpr Esq.Update] ->
@@ -307,6 +315,7 @@ upsert' r u = do
 upsertBy ::
   ( PersistEntity t,
     PersistEntityBackend t ~ SqlBackend,
+    SafeToInsert t,
     ToTType t a
   ) =>
   Unique t ->
@@ -325,7 +334,8 @@ upsertBy k r u = do
 
 upsertBy' ::
   ( PersistEntity t,
-    PersistEntityBackend t ~ SqlBackend
+    PersistEntityBackend t ~ SqlBackend,
+    SafeToInsert t
   ) =>
   Unique t ->
   t ->

--- a/lib/mobility-core/src/Kernel/Streaming/Kafka/Producer.hs
+++ b/lib/mobility-core/src/Kernel/Streaming/Kafka/Producer.hs
@@ -26,8 +26,9 @@ where
 import Data.Aeson (encode)
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Types as A
+import qualified Data.Aeson.Key as AesonKey
+import qualified Data.Aeson.KeyMap as AKM
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.HashMap.Lazy as HM
 import EulerHS.Prelude
 import Kafka.Producer as KafkaProd
 import Kernel.Streaming.Kafka.Producer.Types
@@ -58,5 +59,5 @@ produceMessageImpl (topic, key) event mbPartitionId = do
           prValue = Just . LBS.toStrict $ encode event
         }
 
-(..=) :: ToJSON a => Text -> a -> HM.HashMap Text A.Value
+(..=) :: ToJSON a => AesonKey.Key -> a -> AKM.KeyMap A.Value
 (..=) = (A..=)

--- a/lib/mobility-core/src/Kernel/Streaming/Kafka/Producer.hs
+++ b/lib/mobility-core/src/Kernel/Streaming/Kafka/Producer.hs
@@ -25,9 +25,9 @@ where
 
 import Data.Aeson (encode)
 import qualified Data.Aeson as A
-import qualified Data.Aeson.Types as A
 import qualified Data.Aeson.Key as AesonKey
 import qualified Data.Aeson.KeyMap as AKM
+import qualified Data.Aeson.Types as A
 import qualified Data.ByteString.Lazy as LBS
 import EulerHS.Prelude
 import Kafka.Producer as KafkaProd

--- a/lib/mobility-core/src/Kernel/Types/Beckn/Ack.hs
+++ b/lib/mobility-core/src/Kernel/Types/Beckn/Ack.hs
@@ -15,8 +15,8 @@
 module Kernel.Types.Beckn.Ack where
 
 import Data.Aeson
-import Data.Aeson.Types (unexpected)
 import qualified Data.Aeson.Key as AesonKey (Key)
+import Data.Aeson.Types (unexpected)
 import Data.OpenApi (ToSchema)
 import EulerHS.Prelude
 

--- a/lib/mobility-core/src/Kernel/Types/Beckn/Ack.hs
+++ b/lib/mobility-core/src/Kernel/Types/Beckn/Ack.hs
@@ -16,6 +16,7 @@ module Kernel.Types.Beckn.Ack where
 
 import Data.Aeson
 import Data.Aeson.Types (unexpected)
+import qualified Data.Aeson.Key as AesonKey (Key)
 import Data.OpenApi (ToSchema)
 import EulerHS.Prelude
 
@@ -34,6 +35,6 @@ instance FromJSON AckResponse where
 instance ToJSON AckResponse where
   toJSON Ack = "message" .== "ack" .== "status" .== String "ACK"
     where
-      (.==) :: Text -> Value -> Value
+      (.==) :: AesonKey.Key -> Value -> Value
       k .== v = Object (k .= v)
       infixr 9 .==

--- a/lib/mobility-core/src/Kernel/Types/Beckn/Context.hs
+++ b/lib/mobility-core/src/Kernel/Types/Beckn/Context.hs
@@ -28,7 +28,6 @@ import Kernel.Utils.Example
 import Kernel.Utils.GenericPretty
 import Kernel.Utils.JSON
 import Servant.Client (parseBaseUrl)
-import Data.Maybe (fromJust)
 
 data Context = Context
   { domain :: Domain,

--- a/lib/mobility-core/src/Kernel/Types/Beckn/Context.hs
+++ b/lib/mobility-core/src/Kernel/Types/Beckn/Context.hs
@@ -28,6 +28,7 @@ import Kernel.Utils.Example
 import Kernel.Utils.GenericPretty
 import Kernel.Utils.JSON
 import Servant.Client (parseBaseUrl)
+import Data.Maybe (fromJust)
 
 data Context = Context
   { domain :: Domain,

--- a/lib/mobility-core/src/Kernel/Types/Beckn/DecimalValue.hs
+++ b/lib/mobility-core/src/Kernel/Types/Beckn/DecimalValue.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wwarn=identities #-}
 
 -- Functions rationalToString, validate
 -- are only exported for testing purposes.

--- a/lib/mobility-core/src/Kernel/Types/Beckn/ReqTypes.hs
+++ b/lib/mobility-core/src/Kernel/Types/Beckn/ReqTypes.hs
@@ -18,7 +18,7 @@ import qualified Control.Lens as L
 import Data.Aeson
 import Data.OpenApi
 import Data.Typeable
-import EulerHS.Prelude hiding ((.~), fromList)
+import EulerHS.Prelude hiding (fromList, (.~))
 import GHC.Exts (IsList (fromList))
 import Kernel.Types.Beckn.Context (Context)
 import Kernel.Types.Beckn.Error (Error)

--- a/lib/mobility-core/src/Kernel/Types/Beckn/ReqTypes.hs
+++ b/lib/mobility-core/src/Kernel/Types/Beckn/ReqTypes.hs
@@ -18,7 +18,7 @@ import qualified Control.Lens as L
 import Data.Aeson
 import Data.OpenApi
 import Data.Typeable
-import EulerHS.Prelude hiding ((.~))
+import EulerHS.Prelude hiding ((.~), fromList)
 import GHC.Exts (IsList (fromList))
 import Kernel.Types.Beckn.Context (Context)
 import Kernel.Types.Beckn.Error (Error)

--- a/lib/mobility-core/src/Kernel/Types/Common.hs
+++ b/lib/mobility-core/src/Kernel/Types/Common.hs
@@ -17,6 +17,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wwarn=identities #-}
 
 module Kernel.Types.Common
   ( module Kernel.Types.Common,

--- a/lib/mobility-core/src/Kernel/Types/Flow.hs
+++ b/lib/mobility-core/src/Kernel/Types/Flow.hs
@@ -179,38 +179,6 @@ instance L.MonadFlow (FlowR r) where
 --       `L.delConfig', `L.acquireConfigLock',
 --       `L.releaseConfigLock', and `L.fork'
 
-  -- New methods available & now needed to be provided with upgraded Euler-hs
-
-  {-# INLINEABLE callAPIUsingManager #-}
-  callAPIUsingManager mgr url cl = FlowR $ L.callAPIUsingManager mgr url cl
-
-  {-# INLINEABLE lookupHTTPManager #-}
-  lookupHTTPManager mMgrSel = FlowR $ L.lookupHTTPManager mMgrSel
-
-  {-# INLINEABLE getHTTPManager #-}
-  getHTTPManager settings = FlowR $ L.getHTTPManager settings
-
-  {-# INLINEABLE callHTTPUsingManager #-}
-  callHTTPUsingManager mgr url = FlowR $ L.callHTTPUsingManager mgr url
-
-  {-# INLINEABLE getConfig #-}
-  getConfig k = FlowR $ L.getConfig k
-
-  {-# INLINEABLE setConfig #-}
-  setConfig k v = FlowR $ L.setConfig k v
-
-  {-# INLINEABLE trySetConfig #-}
-  trySetConfig k v = FlowR $ L.trySetConfig k v
-
-  {-# INLINEABLE delConfig #-}
-  delConfig k = FlowR $ L.delConfig k
-
-  {-# INLINEABLE acquireConfigLock #-}
-  acquireConfigLock k = FlowR $ L.acquireConfigLock k
-
-  {-# INLINEABLE releaseConfigLock #-}
-  releaseConfigLock k = FlowR $ L.releaseConfigLock k
-
 instance MonadIO (FlowR r) where
   liftIO = FlowR . L.runIO
 

--- a/lib/mobility-core/src/Kernel/Types/Flow.hs
+++ b/lib/mobility-core/src/Kernel/Types/Flow.hs
@@ -179,6 +179,38 @@ instance L.MonadFlow (FlowR r) where
 --       `L.delConfig', `L.acquireConfigLock',
 --       `L.releaseConfigLock', and `L.fork'
 
+  -- New methods available & now needed to be provided with upgraded Euler-hs
+
+  {-# INLINEABLE callAPIUsingManager #-}
+  callAPIUsingManager mgr url cl = FlowR $ L.callAPIUsingManager mgr url cl
+
+  {-# INLINEABLE lookupHTTPManager #-}
+  lookupHTTPManager mMgrSel = FlowR $ L.lookupHTTPManager mMgrSel
+
+  {-# INLINEABLE getHTTPManager #-}
+  getHTTPManager settings = FlowR $ L.getHTTPManager settings
+
+  {-# INLINEABLE callHTTPUsingManager #-}
+  callHTTPUsingManager mgr url = FlowR $ L.callHTTPUsingManager mgr url
+
+  {-# INLINEABLE getConfig #-}
+  getConfig k = FlowR $ L.getConfig k
+
+  {-# INLINEABLE setConfig #-}
+  setConfig k v = FlowR $ L.setConfig k v
+
+  {-# INLINEABLE trySetConfig #-}
+  trySetConfig k v = FlowR $ L.trySetConfig k v
+
+  {-# INLINEABLE delConfig #-}
+  delConfig k = FlowR $ L.delConfig k
+
+  {-# INLINEABLE acquireConfigLock #-}
+  acquireConfigLock k = FlowR $ L.acquireConfigLock k
+
+  {-# INLINEABLE releaseConfigLock #-}
+  releaseConfigLock k = FlowR $ L.releaseConfigLock k
+
 instance MonadIO (FlowR r) where
   liftIO = FlowR . L.runIO
 

--- a/lib/mobility-core/src/Kernel/Types/Flow.hs
+++ b/lib/mobility-core/src/Kernel/Types/Flow.hs
@@ -73,6 +73,13 @@ instance L.MonadFlow (FlowR r) where
   modifyOption k f = FlowR $ L.modifyOption k f
   {-# INLINEABLE delOptionLocal #-}
   delOptionLocal k = FlowR $ L.delOptionLocal k
+
+  -- "callHTTPWithCert" seems DEPRECATED, it advises the following in Euler-hs comments:-
+  -- Use "getHTTPManager"/"callHTTPUsingManager" instead. This method does not allow custom CA store
+  -- Commenting it out, to be deleted in a later iteration.
+  -- {-# INLINEABLE callHTTPWithCert #-}
+  -- callHTTPWithCert url cert = FlowR $ L.callHTTPWithCert url cert
+
   {-# INLINEABLE evalLogger' #-}
   evalLogger' logAct = FlowR $ L.evalLogger' logAct
   {-# INLINEABLE runIO' #-}

--- a/lib/mobility-core/src/Kernel/Types/Version.hs
+++ b/lib/mobility-core/src/Kernel/Types/Version.hs
@@ -11,7 +11,6 @@
 
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-
 {-# OPTIONS_GHC -Wwarn=incomplete-uni-patterns #-}
 
 module Kernel.Types.Version where

--- a/lib/mobility-core/src/Kernel/Types/Version.hs
+++ b/lib/mobility-core/src/Kernel/Types/Version.hs
@@ -12,6 +12,8 @@
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 
+{-# OPTIONS_GHC -Wwarn=incomplete-uni-patterns #-}
+
 module Kernel.Types.Version where
 
 import Control.Lens

--- a/lib/mobility-core/src/Kernel/Utils/Callback.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Callback.hs
@@ -14,7 +14,8 @@
 
 module Kernel.Utils.Callback (withBecknCallbackMig, WithBecknCallbackMig) where
 
-import EulerHS.Prelude
+import Control.Lens ((.~))
+import EulerHS.Prelude hiding ((.~))
 import qualified EulerHS.Types as ET
 import Kernel.Tools.Metrics.CoreMetrics
 import Kernel.Types.Beckn.Ack

--- a/lib/mobility-core/src/Kernel/Utils/Dhall.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Dhall.hs
@@ -54,11 +54,9 @@ readDhallConfigDefault appname = do
 instance {-# OVERLAPS #-} Num a => FromDhall a where
   autoWith inn = fmap fromInteger (autoWith inn :: Decoder Integer)
 
-#if MIN_VERSION_dhall(1, 35, 0)
-#else
-instance FromDhall Word16 where
-  autoWith inn = fmap fromIntegral (autoWith inn :: Decoder Natural)
-#endif
+-- Use the instance from Dhall itself
+-- instance FromDhall Word16 where
+--   autoWith inn = fmap fromIntegral (autoWith inn :: Decoder Natural)
 
 deriving instance FromDhall Scheme
 

--- a/lib/mobility-core/src/Kernel/Utils/Error/Hierarchy.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Error/Hierarchy.hs
@@ -30,5 +30,5 @@ instanceExceptionWithParent parent child =
   where
     unPat =
       let x = mkName "x"
-       in LamE [ConP parent [VarP x]] $
+       in LamE [ConP parent [] [VarP x]] $
             AppE (VarE 'cast) (VarE x)

--- a/lib/mobility-core/src/Kernel/Utils/FlowLogging.hs
+++ b/lib/mobility-core/src/Kernel/Utils/FlowLogging.hs
@@ -37,7 +37,6 @@ import qualified EulerHS.Types as T
 import Kernel.Types.Logging
 import System.Logger (DateFormat, Renderer, renderDefault)
 import qualified Prelude as P
-import Data.Aeson as A
 import qualified Data.Aeson.KeyMap as AKM
 import qualified Formatting.Buildable as FB (build)
 

--- a/lib/mobility-core/src/Kernel/Utils/FlowLogging.hs
+++ b/lib/mobility-core/src/Kernel/Utils/FlowLogging.hs
@@ -22,6 +22,7 @@ module Kernel.Utils.FlowLogging
 where
 
 import Data.Aeson as A
+import qualified Data.Aeson.KeyMap as AKM
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Strict as HM
@@ -34,11 +35,10 @@ import EulerHS.Prelude
 import EulerHS.Runtime
 import EulerHS.Types (LogContext)
 import qualified EulerHS.Types as T
+import qualified Formatting.Buildable as FB (build)
 import Kernel.Types.Logging
 import System.Logger (DateFormat, Renderer, renderDefault)
 import qualified Prelude as P
-import qualified Data.Aeson.KeyMap as AKM
-import qualified Formatting.Buildable as FB (build)
 
 logOutputImplementation :: L.MonadFlow m => LogLevel -> T.Message -> m ()
 logOutputImplementation logLevel message =
@@ -47,12 +47,12 @@ logOutputImplementation logLevel message =
     INFO -> L.logInfo EmtpyTag msg
     WARNING -> L.logWarning EmtpyTag msg
     ERROR -> L.logError EmtpyTag msg
-    where
-      -- the T.Message type from an older version of Euler-hs
-      -- previously used to be a type-synonym to "Text"
-      -- It is now a record, with a "Buildable" instance
-      -- While the logging functions still expect a Text
-      msg = LT.toStrict . LTB.toLazyText $ FB.build message
+  where
+    -- the T.Message type from an older version of Euler-hs
+    -- previously used to be a type-synonym to "Text"
+    -- It is now a record, with a "Buildable" instance
+    -- While the logging functions still expect a Text
+    msg = LT.toStrict . LTB.toLazyText $ FB.build message
 
 withLogTagImplementation ::
   L.MonadFlow m =>
@@ -151,7 +151,7 @@ logFormatterText
       res =
         T.SimpleLBS . A.encode $
           A.Object $
-            HM.fromList
+            AKM.fromList
               [ ("timestamp", A.String $ show timestamp),
                 ("lvl", A.String $ show lvl),
                 ("msgNum", A.String $ show msgNum),
@@ -175,7 +175,7 @@ logFormatterText
       res =
         T.SimpleLBS . A.encode $
           A.Object $
-            HM.fromList
+            AKM.fromList
               [ ("timestamp", A.String $ show timestamp),
                 ("lvl", A.String $ show lvl),
                 ("msgNum", A.String $ show msgNum),

--- a/lib/mobility-core/src/Kernel/Utils/FlowLogging.hs
+++ b/lib/mobility-core/src/Kernel/Utils/FlowLogging.hs
@@ -26,6 +26,8 @@ import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LT
+import qualified Data.Text.Lazy.Builder as LTB
 import qualified Data.Time as Time
 import qualified EulerHS.Language as L
 import EulerHS.Prelude
@@ -36,13 +38,21 @@ import Kernel.Types.Logging
 import System.Logger (DateFormat, Renderer, renderDefault)
 import qualified Prelude as P
 
-logOutputImplementation :: L.MonadFlow m => LogLevel -> Text.Text -> m ()
+import qualified Formatting.Buildable as FB (build)
+
+logOutputImplementation :: L.MonadFlow m => LogLevel -> T.Message -> m ()
 logOutputImplementation logLevel message =
   case logLevel of
-    DEBUG -> L.logDebug EmtpyTag message
-    INFO -> L.logInfo EmtpyTag message
-    WARNING -> L.logWarning EmtpyTag message
-    ERROR -> L.logError EmtpyTag message
+    DEBUG -> L.logDebug EmtpyTag msg
+    INFO -> L.logInfo EmtpyTag msg
+    WARNING -> L.logWarning EmtpyTag msg
+    ERROR -> L.logError EmtpyTag msg
+    where
+      -- the T.Message type from an older version of Euler-hs
+      -- previously used to be a type-synonym to "Text"
+      -- It is now a record, with a "Buildable" instance
+      -- While the logging functions still expect a Text
+      msg = LT.toStrict . LTB.toLazyText $ FB.build message
 
 withLogTagImplementation ::
   L.MonadFlow m =>

--- a/lib/mobility-core/src/Kernel/Utils/FlowLogging.hs
+++ b/lib/mobility-core/src/Kernel/Utils/FlowLogging.hs
@@ -37,7 +37,8 @@ import qualified EulerHS.Types as T
 import Kernel.Types.Logging
 import System.Logger (DateFormat, Renderer, renderDefault)
 import qualified Prelude as P
-
+import Data.Aeson as A
+import qualified Data.Aeson.KeyMap as AKM
 import qualified Formatting.Buildable as FB (build)
 
 logOutputImplementation :: L.MonadFlow m => LogLevel -> T.Message -> m ()

--- a/lib/mobility-core/src/Kernel/Utils/GenericPretty.hs
+++ b/lib/mobility-core/src/Kernel/Utils/GenericPretty.hs
@@ -31,10 +31,12 @@ module Kernel.Utils.GenericPretty
 where
 
 import Data.Aeson
+import qualified Data.Aeson.Key as AesonKey
+import qualified Data.Aeson.KeyMap as AKM
+import qualified Data.Bifunctor as BFunc
 import qualified Data.ByteString as BS (ByteString)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Fixed
-import qualified Data.HashMap.Strict as HMS
 import qualified Data.List.NonEmpty as NE
 import Data.Scientific
 import qualified Data.Text as Text (Text, pack, unpack)
@@ -235,7 +237,7 @@ instance PrettyShow Value where
   prettyShow Null = LEmpty
 
 instance PrettyShow Object where
-  prettyShow = LLay "" . Layout . map f . HMS.toList
+  prettyShow = LLay "" . Layout . map f . map (BFunc.first AesonKey.toText) . AKM.toList
     where
       f (fieldName, value) = LayoutUnit (Text.unpack fieldName) (prettyShow value)
 

--- a/lib/mobility-core/src/Kernel/Utils/IOLogging.hs
+++ b/lib/mobility-core/src/Kernel/Utils/IOLogging.hs
@@ -36,6 +36,8 @@ import Kernel.Prelude
 import Kernel.Types.Logging
 import Kernel.Types.Time
 import System.Log.FastLogger
+import Data.Aeson as A
+import qualified Data.Aeson.KeyMap as AKM
 
 type HasLog r = HasField "loggerEnv" r LoggerEnv
 
@@ -133,4 +135,4 @@ logFormatterText timestamp hostname lvl tags msg = res
         <> tag
         <> " |> "
         <> msg
-    res = A.Object $ HM.insert "log" (A.String log) HM.empty
+    res = A.Object $ AKM.insert "log" (A.String log) AKM.empty

--- a/lib/mobility-core/src/Kernel/Utils/IOLogging.hs
+++ b/lib/mobility-core/src/Kernel/Utils/IOLogging.hs
@@ -29,13 +29,13 @@ where
 
 import qualified Control.Monad.Catch as C
 import Data.Aeson as A
+import qualified Data.Aeson.KeyMap as AKM
 import qualified Data.Text as T
 import qualified Data.Time as Time
 import Kernel.Prelude
 import Kernel.Types.Logging
 import Kernel.Types.Time
 import System.Log.FastLogger
-import qualified Data.Aeson.KeyMap as AKM
 
 type HasLog r = HasField "loggerEnv" r LoggerEnv
 

--- a/lib/mobility-core/src/Kernel/Utils/IOLogging.hs
+++ b/lib/mobility-core/src/Kernel/Utils/IOLogging.hs
@@ -29,14 +29,12 @@ where
 
 import qualified Control.Monad.Catch as C
 import Data.Aeson as A
-import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 import qualified Data.Time as Time
 import Kernel.Prelude
 import Kernel.Types.Logging
 import Kernel.Types.Time
 import System.Log.FastLogger
-import Data.Aeson as A
 import qualified Data.Aeson.KeyMap as AKM
 
 type HasLog r = HasField "loggerEnv" r LoggerEnv

--- a/lib/mobility-core/src/Kernel/Utils/JSON.hs
+++ b/lib/mobility-core/src/Kernel/Utils/JSON.hs
@@ -15,7 +15,7 @@
 module Kernel.Utils.JSON where
 
 import Data.Aeson (Options (..), SumEncoding (ObjectWithSingleField, UntaggedValue), Value (..), camelTo2, defaultOptions)
-import Data.HashMap.Strict (size, unions)
+import qualified Data.Aeson.KeyMap as AKM
 import Data.Text (pack, replace, toLower, toUpper, unpack)
 import EulerHS.Prelude hiding (pack, unpack)
 import Kernel.Utils.Text (recursiveStrip)
@@ -71,15 +71,15 @@ doubleQuotesRecordFields =
 
 uniteObjects :: [Value] -> Value
 uniteObjects values =
-  let result = unions objects
-   in if size result == sumOfSizes
+  let result = foldl' AKM.union mempty objects
+   in if AKM.size result == sumOfSizes
         then Object result
         else error ("duplication fields in " <> show values)
   where
     objects = map unwrapObject values
     unwrapObject (Object o) = o
     unwrapObject e = error ("expected Object, got " <> show e)
-    sumOfSizes = sum $ map size objects
+    sumOfSizes = sum $ map AKM.size objects
 
 objectWithSingleFieldParsing :: (String -> String) -> Options
 objectWithSingleFieldParsing constructorMapping =

--- a/lib/mobility-core/src/Kernel/Utils/JWT.hs
+++ b/lib/mobility-core/src/Kernel/Utils/JWT.hs
@@ -93,7 +93,7 @@ createJWT sa additionalClaims = do
   case mkey of
     Nothing -> pure $ Left "Bad RSA key!"
     Just pkey -> do
-      let key = RSAPrivateKey pkey
+      let key = EncodeRSAPrivateKey pkey
       iat <- numericDate <$> getPOSIXTime
       exp <- numericDate . (+ 3600) <$> getPOSIXTime
       let searchRequest =

--- a/lib/mobility-core/src/Kernel/Utils/Monitoring/Prometheus/Servant.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Monitoring/Prometheus/Servant.hs
@@ -11,7 +11,6 @@
 
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
-
 {-# OPTIONS_GHC -Wwarn=incomplete-uni-patterns #-}
 
 module Kernel.Utils.Monitoring.Prometheus.Servant where

--- a/lib/mobility-core/src/Kernel/Utils/Monitoring/Prometheus/Servant.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Monitoring/Prometheus/Servant.hs
@@ -12,6 +12,8 @@
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 
+{-# OPTIONS_GHC -Wwarn=incomplete-uni-patterns #-}
+
 module Kernel.Utils.Monitoring.Prometheus.Servant where
 
 import Data.Proxy

--- a/lib/mobility-core/src/Kernel/Utils/Servant/BasicAuth.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Servant/BasicAuth.hs
@@ -16,12 +16,13 @@
 
 module Kernel.Utils.Servant.BasicAuth () where
 
-import Control.Lens (at, (.=), (?=))
+import Control.Lens (at, (.=), (.~), (?=))
 import qualified Data.OpenApi as DS
 import Data.Typeable (typeRep)
-import EulerHS.Prelude
+import EulerHS.Prelude hiding (fromList, (.~))
 import GHC.Exts (fromList)
 import GHC.TypeLits (KnownSymbol)
+import Kernel.Prelude.OrphanInstances ()
 import Servant hiding (ResponseHeader (..))
 import qualified Servant.OpenApi as S
 import qualified Servant.OpenApi.Internal as S

--- a/lib/mobility-core/src/Kernel/Utils/Servant/HeaderAuth.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Servant/HeaderAuth.hs
@@ -17,7 +17,7 @@
 module Kernel.Utils.Servant.HeaderAuth where
 
 import Control.Arrow
-import Control.Lens ((?=), at, (.=), (.~))
+import Control.Lens (at, (.=), (.~), (?=))
 import Data.List (lookup)
 import qualified Data.OpenApi as DS
 import Data.Typeable (typeRep)

--- a/lib/mobility-core/src/Kernel/Utils/Servant/HeaderAuth.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Servant/HeaderAuth.hs
@@ -17,11 +17,11 @@
 module Kernel.Utils.Servant.HeaderAuth where
 
 import Control.Arrow
-import Control.Lens (at, (.=), (?=))
+import Control.Lens ((?=), at, (.=), (.~))
 import Data.List (lookup)
 import qualified Data.OpenApi as DS
 import Data.Typeable (typeRep)
-import EulerHS.Prelude
+import EulerHS.Prelude hiding (fromList, (.~))
 import GHC.Exts (fromList)
 import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
 import Kernel.Tools.Metrics.CoreMetrics (HasCoreMetrics)

--- a/lib/mobility-core/src/Kernel/Utils/Servant/SignatureAuth.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Servant/SignatureAuth.hs
@@ -337,6 +337,20 @@ addAuthManagersToFlowRt flowRt managersList = do
       logInfo $ "Loaded http managers - " <> show (HMS.keys managersSettings)
       createManagersWithTimeout managersSettings timeout
 
+-- Notes on changes:-
+{-
+the type of "_componentsSecuritySchemes" field from Data.OpenApi module
+changed it's representation in openapi3 package version 3.2.0.
+
+it went from being a "Definitions SecurityScheme" to "SecurityDefinitions".
+
+while "Definitions" was just a type-synonym for an "InsOrdHashMap Text".
+The new "SecurityDefinitions" type is newtype wrapper over "Definitions" type
+, Thus it would need it's own instances to be indexable via lens.
+
+These type-class and type-family instances were absent and were added in a previous commit.
+A PR was also opened on the main package repository of the package for this.
+-}
 instance
   ( S.HasOpenApi api,
     KnownSymbol header
@@ -350,7 +364,7 @@ instance
       & addResponse401
     where
       headerName = toText $ symbolVal (Proxy @header)
-      methodName = show $ typeRep (Proxy @Subscriber)
+      methodName = T.pack $ show $ typeRep (Proxy @Subscriber) -- since the "Index SecurityDefinitions" is a "Text"
 
       addSecurityRequirement :: Text -> DS.OpenApi -> DS.OpenApi
       addSecurityRequirement description = execState $ do

--- a/lib/mobility-core/src/Kernel/Utils/Servant/SignatureAuth.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Servant/SignatureAuth.hs
@@ -18,7 +18,7 @@
 module Kernel.Utils.Servant.SignatureAuth where
 
 import Control.Arrow
-import Control.Lens ((?=), at, (.=), (.~))
+import Control.Lens (at, (.=), (.~), (?=))
 import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.CaseInsensitive as CI
@@ -365,7 +365,6 @@ instance
     where
       headerName = toText $ symbolVal (Proxy @header)
       methodName = T.pack $ show $ typeRep (Proxy @Subscriber) -- since the "Index SecurityDefinitions" is a "Text"
-
       addSecurityRequirement :: Text -> DS.OpenApi -> DS.OpenApi
       addSecurityRequirement description = execState $ do
         DS.components . DS.securitySchemes . at methodName ?= securityScheme

--- a/lib/mobility-core/src/Kernel/Utils/Servant/SignatureAuth.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Servant/SignatureAuth.hs
@@ -18,7 +18,7 @@
 module Kernel.Utils.Servant.SignatureAuth where
 
 import Control.Arrow
-import Control.Lens (at, (.=), (?=))
+import Control.Lens ((?=), at, (.=), (.~))
 import qualified "base64-bytestring" Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.CaseInsensitive as CI
@@ -31,7 +31,7 @@ import qualified Data.OpenApi as DS
 import qualified Data.Text as T
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Typeable (typeRep)
-import EulerHS.Prelude
+import EulerHS.Prelude hiding (fromList, (.~))
 import qualified EulerHS.Runtime as R
 import GHC.Exts (fromList)
 import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)

--- a/lib/mobility-core/src/Kernel/Utils/Validation.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Validation.hs
@@ -19,9 +19,10 @@ module Kernel.Utils.Validation
   )
 where
 
+import Control.Lens ((%~))
 import qualified Data.Either.Validation as V
 import Data.Generics.Labels ()
-import EulerHS.Prelude hiding (pred)
+import EulerHS.Prelude hiding (pred, (%~))
 import Kernel.Types.Error.BaseError.HTTPError
 import Kernel.Types.Logging
 import Kernel.Types.Predicate
@@ -36,6 +37,7 @@ runRequestValidation ::
 runRequestValidation validator obj =
   V.validationToEither (validator obj)
     & fromEitherM RequestValidationFailure
+
 
 newtype RequestValidationFailure = RequestValidationFailure [ValidationDescription]
   deriving (Show, IsBaseError, IsBecknAPIError)

--- a/lib/mobility-core/src/Kernel/Utils/Validation.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Validation.hs
@@ -29,16 +29,6 @@ import Kernel.Types.Predicate
 import Kernel.Types.Validation
 import Kernel.Utils.Error.Throwing
 
-runRequestValidation ::
-  (MonadThrow m, Log m) =>
-  Validate obj ->
-  obj ->
-  m ()
-runRequestValidation validator obj =
-  V.validationToEither (validator obj)
-    & fromEitherM RequestValidationFailure
-
-
 newtype RequestValidationFailure = RequestValidationFailure [ValidationDescription]
   deriving (Show, IsBaseError, IsBecknAPIError)
 
@@ -50,6 +40,15 @@ instance IsAPIError RequestValidationFailure where
   toPayload (RequestValidationFailure failures) = toJSON failures
 
 instanceExceptionWithParent 'HTTPException ''RequestValidationFailure
+
+runRequestValidation ::
+  (MonadThrow m, Log m) =>
+  Validate obj ->
+  obj ->
+  m ()
+runRequestValidation validator obj =
+  V.validationToEither (validator obj)
+    & fromEitherM RequestValidationFailure
 
 validateField ::
   (Predicate a p, ShowablePredicate p) =>

--- a/lib/mobility-core/src/Kernel/Utils/Version.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Version.hs
@@ -12,6 +12,7 @@
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# OPTIONS_GHC -Wwarn=incomplete-uni-patterns #-}
 
 module Kernel.Utils.Version (Reexport.versionToText, readVersion) where
 

--- a/lib/mobility-core/test/src/APIExceptions.hs
+++ b/lib/mobility-core/test/src/APIExceptions.hs
@@ -19,7 +19,6 @@
 module APIExceptions (httpExceptionTests) where
 
 import Control.Arrow (left)
-import Data.Maybe (fromJust)
 import qualified Data.Aeson as A
 import Data.Maybe (fromJust)
 import EulerHS.Prelude

--- a/lib/mobility-core/test/src/APIExceptions.hs
+++ b/lib/mobility-core/test/src/APIExceptions.hs
@@ -19,6 +19,7 @@
 module APIExceptions (httpExceptionTests) where
 
 import Control.Arrow (left)
+import Data.Maybe (fromJust)
 import qualified Data.Aeson as A
 import Data.Maybe (fromJust)
 import EulerHS.Prelude

--- a/lib/mobility-core/test/src/SignatureAuth.hs
+++ b/lib/mobility-core/test/src/SignatureAuth.hs
@@ -12,6 +12,7 @@
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE PackageImports #-}
+{-# OPTIONS_GHC -Wwarn=incomplete-uni-patterns #-}
 
 module SignatureAuth
   ( signatureAuthTests,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [x] Refactoring
- [x] Dependency updates

## Description
This PR enables the shared-kernel repository to build with GHC 9.2.7 and all its upgraded package-set and dependencies that come with the upgraded GHC927 package set, updated and rebased to work with the newest commit.

This is part of the larger efforts to upgrade and bring the entire nammayatri ecosystem on GHC 9.2.

To give a brief summary of changes, including but not limited to :- 
- Modifies the codebase to accomodate the updated juspay and internal dependencies, which were in-turn patched to be able to build with GHC 9.2.7 
- Handles and fixes all breaking changes across major version of repositories like Aeson v2+, Text 2+ etc.
- Updates the nix setup accordingly.
- It also upgrades the project tooling like Haskell-Language-Server (HLS) etc.

### Additional Changes
modifies the `flake.nix` and `flake.lock` for dependency upgrades

## Motivation and Context
GHC 9.2 upgrade. A full document of reasons and benefits is being prepared and will be shared internally across teams.


## How did you test it?

- The project builds on my local
- Passes all pre-commit checks
- The entire test-suite builds and passes successfully.

local rideflow testing was also done.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
