### PR TITLE
backend/feat: send subscriber type in registry lookup api

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
             };
             clickhouse-haskell.jailbreak = true;
             generic-deriving.check = false;
+            singletons-th.jailbreak = true;
           };
           autoWire = [ "packages" "checks" ];
         };

--- a/lib/mobility-core/mobility-core.cabal
+++ b/lib/mobility-core/mobility-core.cabal
@@ -454,6 +454,7 @@ library
     , servant-multipart-client
     , servant-openapi3
     , servant-server
+    , singletons-th
     , slack-web
     , stm
     , string-conversions
@@ -608,6 +609,7 @@ test-suite mobility-core-tests
     , servant-multipart-client
     , servant-openapi3
     , servant-server
+    , singletons-th
     , slack-web
     , stm
     , string-conversions

--- a/lib/mobility-core/package.yaml
+++ b/lib/mobility-core/package.yaml
@@ -92,6 +92,7 @@ dependencies:
   - servant-client-core
   - servant-server
   - servant-openapi3
+  - singletons-th
   - text
   - wai
   - warp

--- a/lib/mobility-core/src/Kernel/Types/Beckn/Context.hs
+++ b/lib/mobility-core/src/Kernel/Types/Beckn/Context.hs
@@ -24,6 +24,7 @@ import Kernel.Types.Beckn.City as Reexport
 import Kernel.Types.Beckn.Country as Reexport
 import Kernel.Types.Beckn.Domain as Reexport
 import Kernel.Types.Beckn.IndianState as Reexport
+import qualified Kernel.Types.Registry.Subscriber as Subscriber
 import Kernel.Types.TimeRFC339 (UTCTimeRFC3339 (..))
 import Kernel.Utils.Example
 import Kernel.Utils.GenericPretty
@@ -114,3 +115,6 @@ mapToCbAction = \case
   RATING -> Just ON_RATING
   SUPPORT -> Just ON_SUPPORT
   _ -> Nothing
+
+getSubscriberType :: Action -> Subscriber.SubscriberType
+getSubscriberType action = if isNothing (mapToCbAction action) then Subscriber.BPP else Subscriber.BAP

--- a/lib/mobility-core/src/Kernel/Types/Beckn/Domain.hs
+++ b/lib/mobility-core/src/Kernel/Types/Beckn/Domain.hs
@@ -12,13 +12,15 @@
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Kernel.Types.Beckn.Domain (Domain (..)) where
+module Kernel.Types.Beckn.Domain where
 
 import Data.Aeson
 import Data.Aeson.Types
 import Data.OpenApi hiding (Example)
+import Data.Singletons.TH
 import EulerHS.Prelude
 import Kernel.Beam.Lib.UtilsTH (mkBeamInstancesForEnumAndList)
 import Kernel.Storage.Esqueleto
@@ -42,6 +44,8 @@ data Domain
 
 $(mkBeamInstancesForEnumAndList ''Domain)
 
+genSingletons [''Domain]
+
 instance Example Domain where
   example = MOBILITY
 
@@ -49,7 +53,7 @@ instance FromJSON Domain where
   parseJSON (String "nic2004:60221") = pure MOBILITY
   parseJSON (String "ONDC:TRV10") = pure MOBILITY
   parseJSON (String "nic2004:52110") = pure LOCAL_RETAIL
-  parseJSON (String "nic2004:60212") = pure METRO
+  -- parseJSON (String "nic2004:60212") = pure METRO
   parseJSON (String "nic2004:63031") = pure PARKING
   parseJSON (String "ONDC:TRV11") = pure PUBLIC_TRANSPORT
   parseJSON (String "nic2004:60232") = pure LOGISTICS
@@ -59,7 +63,7 @@ instance FromJSON Domain where
 instance ToJSON Domain where
   toJSON MOBILITY = String "ONDC:TRV10"
   toJSON LOCAL_RETAIL = String "nic2004:52110"
-  toJSON METRO = String "nic2004:60212"
+  toJSON METRO = String "ONDC:TRV11"
   toJSON PARKING = String "nic2004:63031"
   toJSON PUBLIC_TRANSPORT = String "ONDC:TRV11"
   toJSON LOGISTICS = String "nic2004:60232"

--- a/lib/mobility-core/src/Kernel/Types/Registry.hs
+++ b/lib/mobility-core/src/Kernel/Types/Registry.hs
@@ -19,6 +19,7 @@ module Kernel.Types.Registry
 where
 
 import Kernel.Prelude
+import qualified Kernel.Types.Beckn.Domain as Domain
 import Kernel.Types.Registry.Subscriber as E
 
 class Registry m where
@@ -27,7 +28,9 @@ class Registry m where
 data SimpleLookupRequest = SimpleLookupRequest
   { unique_key_id :: Text,
     subscriber_id :: Text,
-    merchant_id :: Text
+    merchant_id :: Text,
+    subscriber_type :: E.SubscriberType,
+    domain :: Domain.Domain
   }
   deriving (Eq, Ord)
 

--- a/lib/mobility-core/src/Kernel/Types/Registry/Subscriber.hs
+++ b/lib/mobility-core/src/Kernel/Types/Registry/Subscriber.hs
@@ -114,7 +114,7 @@ data SubscriberType
   | LREG
   | CREG
   | RREG
-  deriving (Show, Read, Generic, Eq, ToSchema, FromJSON, ToJSON, FromDhall)
+  deriving (Show, Read, Generic, Eq, Ord, ToSchema, FromJSON, ToJSON, FromDhall)
 
 data SubscriberStatus
   = INITIATED

--- a/lib/mobility-core/src/Kernel/Utils/Registry.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Registry.hs
@@ -60,7 +60,8 @@ registryLookup registryUrl request =
       API.emptyLookupRequest
         { API.unique_key_id = Just unique_key_id,
           API.subscriber_id = Just subscriber_id,
-          API.domain = Just MOBILITY
+          API.domain = Just domain,
+          API._type = Just subscriber_type
         }
 
 registryFetch ::
@@ -71,7 +72,7 @@ registryFetch ::
   API.LookupRequest ->
   m [Subscriber]
 registryFetch registryUrl request = do
-  callAPI registryUrl (T.client Registry.lookupAPI request) "lookup" (Registry.lookupAPI)
+  callAPI registryUrl (T.client Registry.lookupAPI request) "lookup" Registry.lookupAPI
     >>= fromEitherM (ExternalAPICallError (Just "REGISTRY_CALL_ERROR") registryUrl)
 
 checkBlacklisted ::


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Fix registry lookup in shared kernel
Include domain and type in lookup API

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
