### PR TITLE
backend/fix: fixed parsing of IdfyResult depending on doc type

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Verification/Interface/Idfy.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Interface/Idfy.hs
@@ -375,35 +375,14 @@ getTask cfg req updateResp = do
   let url = cfg.url
   apiKey <- decrypt cfg.apiKey
   accountId <- decrypt cfg.accountId
-  (resp, respDump) <- Idfy.getTask apiKey accountId url req.requestId
+  (VerificationResponse resp, respDump) <- Idfy.getTask apiKey accountId url req.requestId
   updateResp resp.status (Just respDump) req.requestId
-  case resp.result of
-    Just (DLResult out) ->
-      case out of
-        Idfy.Output {Idfy.source_output = Just op} ->
-          pure $ DLResp (convertDLOutputToDLVerificationOutput op)
-        Idfy.Output {Idfy.source_output = Nothing} ->
-          throwError $ InternalError "DLResult without source_output"
-    Just (RCResult out) ->
-      case out of
-        Idfy.Output {Idfy.extraction_output = Just op} ->
-          pure $ RCResp (convertRCOutputToRCVerificationResponse op)
-        Idfy.Output {Idfy.extraction_output = Nothing} ->
-          throwError $ InternalError "RCResult without extraction_output"
-    Just (PanResult out) ->
-      case out of
-        Idfy.Output {Idfy.source_output = Just op} ->
-          pure $ PanResp (convertPanOutputToPanVerification op)
-        Idfy.Output {Idfy.source_output = Nothing} ->
-          throwError $ InternalError "PanResult without source_output"
-    Just (GstResult out) ->
-      case out of
-        Idfy.Output {Idfy.source_output = Just op} ->
-          pure $ GstResp (convertGstOutputToGstVerification op)
-        Idfy.Output {Idfy.source_output = Nothing} ->
-          throwError $ InternalError "GstResult without source_output"
-    Nothing ->
-      throwError $ InternalError ("Missing result in getTask response: " <> show resp)
+  result <- resp.result & fromMaybeM (InternalError ("Missing result in getTask response: " <> show resp))
+  pure $ case result of
+    DLResult (SourceOutput out) -> DLResp $ convertDLOutputToDLVerificationOutput out
+    RCResult (ExtractionOutput out) -> RCResp $ convertRCOutputToRCVerificationResponse out
+    PanResult (SourceOutput out) -> PanResp $ convertPanOutputToPanVerification out
+    GstResult (SourceOutput out) -> GstResp $ convertGstOutputToGstVerification out
 
 convertDLOutputToDLVerificationOutput :: DLVerificationOutput -> DLVerificationOutputInterface
 convertDLOutputToDLVerificationOutput DLVerificationOutput {..} =
@@ -447,8 +426,16 @@ convertPanOutputToPanVerification PanVerificationOutput {..} =
       panStatus = pan_status,
       nameMatch = name_match,
       dobMatch = dob_match,
-      inputDetails = input_details,
-      status = pan_status
+      inputDetails = convertPanInputDetaills <$> input_details,
+      status = status
+    }
+
+convertPanInputDetaills :: PanInputDetails -> VT.PanInputDetails
+convertPanInputDetaills PanInputDetails {..} =
+  VT.PanInputDetails
+    { inputPanNumber = input_pan_number,
+      inputName = input_name,
+      inputDob = input_dob
     }
 
 convertGstOutputToGstVerification :: GstVerificationOutput -> VT.GstVerificationResponse

--- a/lib/mobility-core/src/Kernel/External/Verification/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Types.hs
@@ -73,12 +73,19 @@ data RCVerificationResponse = RCVerificationResponse
   }
   deriving (Show, FromJSON, ToJSON, Generic, ToSchema)
 
+data PanInputDetails = PanInputDetails
+  { inputPanNumber :: Text,
+    inputName :: Maybe Text,
+    inputDob :: Maybe Text
+  }
+  deriving (Show, FromJSON, ToJSON, Generic, ToSchema)
+
 data PanVerificationResponse = PanVerificationResponse
   { aadhaarSeedingStatus :: Maybe Bool,
     panStatus :: Maybe Text,
     nameMatch :: Maybe Bool,
     dobMatch :: Maybe Bool,
-    inputDetails :: Maybe A.Value,
+    inputDetails :: Maybe PanInputDetails,
     status :: Maybe Text
   }
   deriving (Show, FromJSON, ToJSON, Generic, ToSchema)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
