### PR TITLE
feat: add useDomainOffers config to payment configs

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Payment/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface.hs
@@ -513,6 +513,12 @@ offerSKUConfig = \case
   StripeConfig _ -> Nothing
   PaytmEDCConfig _ -> Nothing
 
+getUseDomainOffers :: PaymentServiceConfig -> Bool
+getUseDomainOffers = \case
+  JuspayConfig cfg -> fromMaybe False cfg.useDomainOffers
+  StripeConfig cfg -> fromMaybe False cfg.useDomainOffers
+  PaytmEDCConfig _ -> False
+
 -- | Unified payment creation. Routes to Juspay createOrder or Stripe createPaymentIntent
 --   based on PaymentServiceConfig. Domain code calls this single function.
 createPayment ::

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
@@ -771,7 +771,8 @@ mkOfferOrder OfferOrder {..} planId registrationDate dutyDate paymentMode numOfR
       udf5 = do
         let strNumRides = show numOfRides
         if strNumRides == "-1" then "DEFAULT" else strNumRides,
-      udf6 = parseUDF6 <$> offerListingMetric
+      udf6 = parseUDF6 <$> offerListingMetric,
+      basket = decodeUtf8 . A.encode <$> basket
     }
   where
     parseUDF6 offerListingMetric' = do
@@ -800,7 +801,16 @@ mkOfferResp Juspay.OfferResp {..} = do
       discountAmount = read $ T.unpack order_breakup.discount_amount,
       cashbackAmount = read $ T.unpack order_breakup.cashback_amount,
       benefitType = benefitType',
-      offerCode = offer_code
+      offerCode = offer_code,
+      productDiscounts = map mkProductDiscount <$> order_breakup.product_discounts
+    }
+
+mkProductDiscount :: Juspay.JuspayProductDiscount -> ProductDiscount
+mkProductDiscount Juspay.JuspayProductDiscount {..} =
+  ProductDiscount
+    { productId = product_id,
+      discountAmount = read $ T.unpack discount_amount,
+      cashbackAmount = read $ T.unpack cashback_amount
     }
 
 mkOfferDescription :: Juspay.OfferDescription -> OfferDescription

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
@@ -876,7 +876,8 @@ mkOfferApplyReq merchantId OfferApplyReq {..} = do
             udf3 = paymentMode,
             udf4 = pack $ formatTime defaultTimeLocale "%d_%m_%y" dutyDate,
             udf5 = show numOfRides,
-            payment_channel = Just "WEB"
+            payment_channel = Just "WEB",
+            basket = decodeUtf8 . A.encode <$> basket
           }
   Juspay.OfferApplyReq
     { txn_id = txnId,
@@ -890,10 +891,15 @@ buildOfferApplyResp :: (MonadThrow m, Log m) => Juspay.OfferApplyResp -> m Offer
 buildOfferApplyResp resp = do
   offers <- forM resp.offers $ \offer -> do
     finalOrderAmount <- parseMoney offer.order_breakup.final_order_amount "final_order_amount"
+    discountAmount <- parseMoney (fromMaybe "0" offer.order_breakup.discount_amount) "discount_amount"
+    cashbackAmount <- parseMoney (fromMaybe "0" offer.order_breakup.cashback_amount) "cashback_amount"
     pure
       OfferApplyRespItem
         { finalOrderAmount,
-          offerId = offer.offer_id
+          discountAmount,
+          cashbackAmount,
+          offerId = offer.offer_id,
+          productDiscounts = map mkProductDiscount <$> offer.order_breakup.product_discounts
         }
   pure OfferApplyResp {offers}
 

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
@@ -797,6 +797,7 @@ mkOfferResp Juspay.OfferResp {..} = do
       orderAmount = read $ T.unpack order_breakup.final_order_amount,
       finalOrderAmount = read $ T.unpack order_breakup.final_order_amount,
       discountAmount = read $ T.unpack order_breakup.discount_amount,
+      cashbackAmount = read $ T.unpack order_breakup.cashback_amount,
       offerCode = offer_code
     }
 

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
@@ -790,6 +790,7 @@ buildOfferListResp resp = do
 
 mkOfferResp :: Juspay.OfferResp -> OfferResp
 mkOfferResp Juspay.OfferResp {..} = do
+  let benefitType' = maybe "DISCOUNT" (._type) (listToMaybe order_breakup.benefits)
   OfferResp
     { offerId = offer_id,
       status,
@@ -798,6 +799,7 @@ mkOfferResp Juspay.OfferResp {..} = do
       finalOrderAmount = read $ T.unpack order_breakup.final_order_amount,
       discountAmount = read $ T.unpack order_breakup.discount_amount,
       cashbackAmount = read $ T.unpack order_breakup.cashback_amount,
+      benefitType = benefitType',
       offerCode = offer_code
     }
 

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
@@ -505,6 +505,7 @@ data OfferResp = OfferResp
     orderAmount :: HighPrecMoney,
     finalOrderAmount :: HighPrecMoney,
     discountAmount :: HighPrecMoney,
+    cashbackAmount :: HighPrecMoney,
     offerCode :: Text
   }
   deriving (Generic, Show, FromJSON, ToJSON)

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
@@ -452,7 +452,8 @@ data UDF6 = IS_VISIBLE | IS_APPLICABLE | LIST_BASED_ON_DATE UTCTime
 data OfferOrder = OfferOrder
   { orderId :: Maybe Text,
     amount :: HighPrecMoney,
-    currency :: Currency
+    currency :: Currency,
+    basket :: Maybe [Basket]
   }
 
 data OfferCustomer = OfferCustomer
@@ -507,7 +508,16 @@ data OfferResp = OfferResp
     discountAmount :: HighPrecMoney,
     cashbackAmount :: HighPrecMoney,
     benefitType :: Text, -- "CASHBACK" or "DISCOUNT"
-    offerCode :: Text
+    offerCode :: Text,
+    productDiscounts :: Maybe [ProductDiscount]
+  }
+  deriving (Generic, Show, FromJSON, ToJSON)
+  deriving anyclass (ToSchema)
+
+data ProductDiscount = ProductDiscount
+  { productId :: Text,
+    discountAmount :: HighPrecMoney,
+    cashbackAmount :: HighPrecMoney
   }
   deriving (Generic, Show, FromJSON, ToJSON)
   deriving anyclass (ToSchema)

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
@@ -543,7 +543,8 @@ data OfferApplyReq = OfferApplyReq
     registrationDate :: UTCTime,
     dutyDate :: UTCTime,
     paymentMode :: Text,
-    numOfRides :: Int
+    numOfRides :: Int,
+    basket :: Maybe [Basket]
   }
 
 newtype OfferApplyResp = OfferApplyResp
@@ -552,7 +553,10 @@ newtype OfferApplyResp = OfferApplyResp
 
 data OfferApplyRespItem = OfferApplyRespItem
   { offerId :: Text,
-    finalOrderAmount :: HighPrecMoney
+    finalOrderAmount :: HighPrecMoney,
+    discountAmount :: HighPrecMoney,
+    cashbackAmount :: HighPrecMoney,
+    productDiscounts :: Maybe [ProductDiscount]
   }
 
 -- offer notify --

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
@@ -506,6 +506,7 @@ data OfferResp = OfferResp
     finalOrderAmount :: HighPrecMoney,
     discountAmount :: HighPrecMoney,
     cashbackAmount :: HighPrecMoney,
+    benefitType :: Text, -- "CASHBACK" or "DISCOUNT"
     offerCode :: Text
   }
   deriving (Generic, Show, FromJSON, ToJSON)

--- a/lib/mobility-core/src/Kernel/External/Payment/Juspay/Config.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Juspay/Config.hs
@@ -38,7 +38,8 @@ data JuspayCfg = JuspayCfg
     autoRefundConflictThresholdMinutes :: Maybe Int,
     walletIssuer :: Maybe Text,
     walletRewardApiVersion :: Maybe Text,
-    mockStatusUrl :: Maybe BaseUrl
+    mockStatusUrl :: Maybe BaseUrl,
+    useDomainOffers :: Maybe Bool
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)

--- a/lib/mobility-core/src/Kernel/External/Payment/Juspay/Types/Offer.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Juspay/Types/Offer.hs
@@ -42,7 +42,8 @@ data OfferOrder = OfferOrder
     udf3 :: Text,
     udf4 :: Text,
     udf5 :: Text,
-    udf6 :: Maybe Text
+    udf6 :: Maybe Text,
+    basket :: Maybe Text
   }
   deriving stock (Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
@@ -110,7 +111,16 @@ data OrderBreakup = OrderBreakup
     merchant_discount_amount :: Text,
     cashback_amount :: Text,
     offer_amount :: Text,
-    benefits :: [BestOfferCombinationBenefit]
+    benefits :: [BestOfferCombinationBenefit],
+    product_discounts :: Maybe [JuspayProductDiscount]
+  }
+  deriving stock (Show, Generic)
+  deriving anyclass (FromJSON, ToJSON, ToSchema)
+
+data JuspayProductDiscount = JuspayProductDiscount
+  { product_id :: Text,
+    discount_amount :: Text,
+    cashback_amount :: Text
   }
   deriving stock (Show, Generic)
   deriving anyclass (FromJSON, ToJSON, ToSchema)

--- a/lib/mobility-core/src/Kernel/External/Payment/Juspay/Types/Offer.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Juspay/Types/Offer.hs
@@ -202,7 +202,8 @@ data OfferApplyOrder = OfferApplyOrder
     udf3 :: Text,
     udf4 :: Text,
     udf5 :: Text,
-    payment_channel :: Maybe Text
+    payment_channel :: Maybe Text,
+    basket :: Maybe Text
   }
   deriving stock (Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
@@ -240,8 +241,11 @@ data OfferApplyOffer = OfferApplyOffer
   deriving stock (Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
-newtype OfferApplyOrderBreakup = OfferApplyOrderBreakup
-  { final_order_amount :: Text
+data OfferApplyOrderBreakup = OfferApplyOrderBreakup
+  { final_order_amount :: Text,
+    discount_amount :: Maybe Text,
+    cashback_amount :: Maybe Text,
+    product_discounts :: Maybe [JuspayProductDiscount]
   }
   deriving stock (Show, Generic)
   deriving anyclass (FromJSON, ToJSON)

--- a/lib/mobility-core/src/Kernel/External/Payment/Stripe/Config.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Stripe/Config.hs
@@ -38,7 +38,8 @@ data StripeCfg = StripeCfg
     chargeDestination :: ChargeDestination,
     webhookEndpointSecret :: Maybe (EncryptedField 'AsEncrypted Text),
     webhookToleranceSeconds :: Maybe Seconds,
-    serviceMode :: Maybe ServiceMode
+    serviceMode :: Maybe ServiceMode,
+    useDomainOffers :: Maybe Bool
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)


### PR DESCRIPTION
## Summary
- Adds `useDomainOffers :: Maybe Bool` to `JuspayCfg` and `StripeCfg`
- Adds `getUseDomainOffers :: PaymentServiceConfig -> Bool` helper in `Interface.hs`
- Allows nammayatri to configure whether domain-based offers (local DB) or payment gateway offers are used, per payment config instead of hardcoded by service type

## Test plan
- [ ] Verify `cabal build all` compiles successfully
- [ ] Verify backward compatibility: absent `useDomainOffers` field defaults to `False` via `Maybe Bool` + `fromMaybe False`
- [ ] Verify JSON deserialization with and without the new field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional domain-offers configuration for Juspay and Stripe integrations.
  * Offer responses now include cashbackAmount and benefitType (defaults to "DISCOUNT" when unspecified).
  * Offer payloads and apply requests can include a basket.
  * Responses expose product-level discounts and cashback details per item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->