### PR TITLE
fix : juspay payout webhook 500 error fix by changing the type of Pay…

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Payout/Interface/Juspay.hs
+++ b/lib/mobility-core/src/Kernel/External/Payout/Interface/Juspay.hs
@@ -165,16 +165,17 @@ payoutOrderStatusWebhook payoutConfig authData val = do
 
 mkWebhookOrderStatusPayoutResp :: Juspay.PayoutWebhookReq -> OrderStatusPayoutResp
 mkWebhookOrderStatusPayoutResp payoutReq = case payoutReq.label of
-  Just "ORDER" -> parsePayoutWebhook -- consuming only order level webhooks
+  Just "ORDER" -> case payoutReq.info.merchantOrderId of -- consuming only order level webhooks
+    Just orderId
+      | not (T.null (T.strip orderId)) ->
+        OrderStatusPayoutResp
+          { payoutOrderId = orderId,
+            payoutStatus = payoutReq.info.status,
+            orderType = payoutReq.info._type,
+            merchantCustomerId = payoutReq.info.merchantCustomerId,
+            amount = realToFrac payoutReq.info.amount,
+            createdAt = payoutReq.info.createdAt,
+            updatedAt = payoutReq.info.updatedAt
+          }
+    _ -> BadStatusResp
   _ -> BadStatusResp
-  where
-    parsePayoutWebhook =
-      OrderStatusPayoutResp
-        { payoutOrderId = payoutReq.info.merchantOrderId,
-          payoutStatus = payoutReq.info.status,
-          orderType = payoutReq.info._type,
-          merchantCustomerId = payoutReq.info.merchantCustomerId,
-          amount = realToFrac payoutReq.info.amount,
-          createdAt = payoutReq.info.createdAt,
-          updatedAt = payoutReq.info.updatedAt
-        }

--- a/lib/mobility-core/src/Kernel/External/Payout/Juspay/Types/Webhook.hs
+++ b/lib/mobility-core/src/Kernel/External/Payout/Juspay/Types/Webhook.hs
@@ -35,7 +35,7 @@ data PayoutInfo = PayoutInfo
   { id :: Text,
     status :: Payout.PayoutOrderStatus,
     _type :: Maybe Text,
-    merchantOrderId :: Text,
+    merchantOrderId :: Maybe Text,
     amount :: Double,
     merchantCustomerId :: Maybe Text,
     createdAt :: Maybe Text,


### PR DESCRIPTION
…outInfo

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ORDER-type payout webhooks now require a non-empty merchant order ID; requests with a missing or whitespace-only ID are rejected with an explicit error instead of being processed.
  * The payout webhook model treats merchant order ID as optional, so absent or null IDs are handled safely and validated before processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->