### PR TITLE
Backend/feat: Add Kernel.External.EventTracking for S2S event tracking

### DIFF
--- a/lib/mobility-core/mobility-core.cabal
+++ b/lib/mobility-core/mobility-core.cabal
@@ -70,6 +70,14 @@ library
       Kernel.External.Call.Twillio.Config
       Kernel.External.Call.Types
       Kernel.External.Encryption
+      Kernel.External.EventTracking
+      Kernel.External.EventTracking.Interface
+      Kernel.External.EventTracking.Interface.Types
+      Kernel.External.EventTracking.Moengage.API
+      Kernel.External.EventTracking.Moengage.Config
+      Kernel.External.EventTracking.Moengage.Flow
+      Kernel.External.EventTracking.Moengage.Types
+      Kernel.External.EventTracking.Types
       Kernel.External.GoogleTranslate.API
       Kernel.External.GoogleTranslate.Client
       Kernel.External.GoogleTranslate.Types

--- a/lib/mobility-core/src/Kernel/External/EventTracking.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking.hs
@@ -1,0 +1,23 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.EventTracking
+  ( module Kernel.External.EventTracking.Interface,
+    module Kernel.External.EventTracking.Types,
+  )
+where
+
+import Kernel.External.EventTracking.Interface
+import Kernel.External.EventTracking.Types
+import Kernel.Prelude ()

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Interface.hs
@@ -1,0 +1,42 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.EventTracking.Interface
+  ( pushEvent,
+    module Reexport,
+  )
+where
+
+import Kernel.External.Encryption
+import Kernel.External.EventTracking.Interface.Types as Reexport
+import qualified Kernel.External.EventTracking.Moengage.Flow as MoengageFlow
+import Kernel.External.EventTracking.Moengage.Types
+import Kernel.Prelude
+import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
+import Kernel.Types.Common
+import Kernel.Utils.Common (HasRequestId)
+
+-- | Push event to event tracking provider - dispatches to appropriate provider
+pushEvent ::
+  ( EncFlow m r,
+    CoreMetrics m,
+    MonadFlow m,
+    HasRequestId r,
+    MonadReader r m
+  ) =>
+  EventTrackingServiceConfig ->
+  MoengageEventReq ->
+  m (Maybe MoengageEventResp)
+pushEvent config req = case config of
+  MoengageConfig moengageCfg -> MoengageFlow.pushEvent moengageCfg req

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Interface/Types.hs
@@ -1,0 +1,32 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+
+module Kernel.External.EventTracking.Interface.Types
+  ( EventTrackingServiceConfig (..),
+  )
+where
+
+import Data.Aeson
+import Deriving.Aeson
+import qualified Kernel.External.EventTracking.Moengage.Config as MoengageConfig
+import Kernel.Prelude
+
+-- | Configuration sum type for all event tracking providers
+data EventTrackingServiceConfig
+  = MoengageConfig MoengageConfig.MoengageCfg
+  deriving (Show, Eq, Generic)
+  deriving (FromJSON, ToJSON) via CustomJSON '[SumTaggedObject "tag" "content"] EventTrackingServiceConfig

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Moengage/API.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Moengage/API.hs
@@ -1,0 +1,33 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.EventTracking.Moengage.API
+  ( MoengageEventAPI,
+    moengageEventAPI,
+  )
+where
+
+import Kernel.External.EventTracking.Moengage.Types
+import Kernel.Prelude
+import Servant
+
+type MoengageEventAPI =
+  "v1" :> "event"
+    :> Capture "app_id" Text
+    :> Header "Authorization" Text
+    :> ReqBody '[JSON] MoengageEventReq
+    :> Post '[JSON] MoengageEventResp
+
+moengageEventAPI :: Proxy MoengageEventAPI
+moengageEventAPI = Proxy

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Moengage/Config.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Moengage/Config.hs
@@ -1,0 +1,27 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.EventTracking.Moengage.Config where
+
+import Kernel.External.Encryption
+import Kernel.Prelude
+
+-- | Configuration for Moengage S2S API
+data MoengageCfg = MoengageCfg
+  { baseUrl :: BaseUrl,
+    appId :: Text,
+    apiSecret :: EncryptedField 'AsEncrypted Text,
+    enabled :: Bool
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Moengage/Flow.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Moengage/Flow.hs
@@ -1,0 +1,59 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+{-# LANGUAGE PackageImports #-}
+
+module Kernel.External.EventTracking.Moengage.Flow
+  ( pushEvent,
+  )
+where
+
+import qualified "base64-bytestring" Data.ByteString.Base64 as B64
+import qualified Data.Text.Encoding as TE
+import EulerHS.Types (client)
+import Kernel.External.Encryption (decrypt)
+import Kernel.External.EventTracking.Moengage.API
+import Kernel.External.EventTracking.Moengage.Config
+import Kernel.External.EventTracking.Moengage.Types
+import Kernel.Prelude
+import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
+import Kernel.Types.Common
+import Kernel.Types.Error
+import Kernel.Utils.Common
+
+-- | Push an event to Moengage S2S API
+pushEvent ::
+  ( EncFlow m r,
+    CoreMetrics m,
+    MonadFlow m,
+    HasRequestId r,
+    MonadReader r m
+  ) =>
+  MoengageCfg ->
+  MoengageEventReq ->
+  m (Maybe MoengageEventResp)
+pushEvent cfg req = do
+  if not cfg.enabled
+    then pure Nothing
+    else do
+      apiSecret <- decrypt cfg.apiSecret
+      let authToken = buildBasicAuth cfg.appId apiSecret
+          moengageClient = client (Proxy :: Proxy MoengageEventAPI)
+      resp <-
+        callAPI cfg.baseUrl (moengageClient cfg.appId (Just authToken) req) "moengageEvent" moengageEventAPI
+          >>= fromEitherM (const $ InternalError "Failed to call Moengage Event API")
+      pure (Just resp)
+
+buildBasicAuth :: Text -> Text -> Text
+buildBasicAuth appId apiSecret =
+  "Basic " <> TE.decodeUtf8 (B64.encode (TE.encodeUtf8 (appId <> ":" <> apiSecret)))

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Moengage/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Moengage/Types.hs
@@ -1,0 +1,43 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.EventTracking.Moengage.Types where
+
+import Data.Aeson (Value)
+import Kernel.Prelude
+import Kernel.Utils.JSON (stripPrefixUnderscoreIfAny)
+
+data MoengageEventReq = MoengageEventReq
+  { _type :: Text,
+    customer_id :: Text,
+    actions :: [MoengageAction]
+  }
+  deriving (Show, Generic)
+
+instance ToJSON MoengageEventReq where
+  toJSON = genericToJSON stripPrefixUnderscoreIfAny
+
+instance FromJSON MoengageEventReq where
+  parseJSON = genericParseJSON stripPrefixUnderscoreIfAny
+
+data MoengageAction = MoengageAction
+  { action :: Text,
+    attributes :: Value
+  }
+  deriving (Show, Generic, ToJSON, FromJSON)
+
+data MoengageEventResp = MoengageEventResp
+  { status :: Text
+  }
+  deriving (Show, Generic, ToJSON, FromJSON)

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Types.hs
@@ -1,0 +1,32 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Kernel.External.EventTracking.Types
+  ( EventTrackingService (..),
+    availableEventTrackingServices,
+  )
+where
+
+import Data.Aeson
+import Kernel.Prelude
+
+-- | Enum of event tracking service providers
+data EventTrackingService
+  = Moengage
+  deriving (Show, Read, Eq, Ord, Generic, ToJSON, FromJSON)
+
+-- | List of all available event tracking services
+availableEventTrackingServices :: [EventTrackingService]
+availableEventTrackingServices = [Moengage]


### PR DESCRIPTION
## Summary
- Adds `Kernel.External.EventTracking` as a new external service integration for S2S event tracking
- Follows the standard `Kernel.External` pattern (same as SOS, SMS, Insurance, etc.)
- **Moengage** is the first provider; structure supports adding CleverTap, WebEngage etc. as future providers
- Structure: `EventTracking/` (service) → `Moengage/` (provider)

## Files Added
| File | Purpose |
|------|---------|
| `EventTracking.hs` | Re-export module |
| `EventTracking/Types.hs` | `EventTrackingService` enum (provider list) |
| `EventTracking/Interface.hs` | Dispatcher — routes to correct provider |
| `EventTracking/Interface/Types.hs` | `EventTrackingServiceConfig` sum type (stored in DB) |
| `EventTracking/Moengage/Config.hs` | `MoengageCfg` — credentials with encrypted apiSecret |
| `EventTracking/Moengage/Types.hs` | Moengage API request/response types |
| `EventTracking/Moengage/API.hs` | Servant API type for Moengage event endpoint |
| `EventTracking/Moengage/Flow.hs` | `pushEvent` — decrypts secret, builds Basic auth, calls API |

## Design
- `pushEvent` returns `Maybe MoengageEventResp` — `Nothing` when disabled (no-op, no error)
- Error messages are sanitized — no raw `ClientError` details leaked
- `enabled` flag in config acts as kill switch per provider
- Adding a new provider = new folder + new variant in `EventTrackingServiceConfig` + one case in dispatcher

## Test plan
- [ ] Verify `cabal build mobility-core` compiles
- [ ] Verify JSON serialization of `EventTrackingServiceConfig` roundtrips correctly
- [ ] Integration test with Moengage S2S Event API using test credentials