### PR TITLE
aarokya-integ

### DIFF
--- a/lib/mobility-core/mobility-core.cabal
+++ b/lib/mobility-core/mobility-core.cabal
@@ -155,6 +155,12 @@ library
       Kernel.External.Notification.PayTM.Client
       Kernel.External.Notification.PayTM.Types
       Kernel.External.Notification.Types
+      Kernel.External.PartnerSdk.Aarokya.Flow
+      Kernel.External.PartnerSdk.Aarokya.Types
+      Kernel.External.PartnerSdk.Interface
+      Kernel.External.PartnerSdk.Interface.Aarokya
+      Kernel.External.PartnerSdk.Interface.Types
+      Kernel.External.PartnerSdk.Types
       Kernel.External.Payment.Interface
       Kernel.External.Payment.Interface.Events.Types
       Kernel.External.Payment.Interface.Juspay

--- a/lib/mobility-core/src/Kernel/External/PartnerSdk/Aarokya/Flow.hs
+++ b/lib/mobility-core/src/Kernel/External/PartnerSdk/Aarokya/Flow.hs
@@ -1,0 +1,32 @@
+module Kernel.External.PartnerSdk.Aarokya.Flow where
+
+import EulerHS.Types as Euler
+import Kernel.External.PartnerSdk.Aarokya.Types
+import Kernel.Prelude
+import qualified Kernel.Tools.Metrics.CoreMetrics as Metrics
+import Kernel.Types.Error
+import Kernel.Utils.Common
+import Servant hiding (throwError)
+
+type GenerateTokenAPI =
+  "auth"
+    :> "token"
+    :> Header "api-key" Text
+    :> ReqBody '[JSON] AarokyaTokenRequest
+    :> Post '[JSON] AarokyaTokenResponse
+
+generateToken ::
+  (Metrics.CoreMetrics m, MonadFlow m, HasRequestId r, MonadReader r m) =>
+  BaseUrl ->
+  Text ->
+  AarokyaTokenRequest ->
+  m AarokyaTokenResponse
+generateToken url apiKey request = do
+  let proxy = Proxy @GenerateTokenAPI
+      eulerClient = Euler.client proxy (Just apiKey) request
+  callAarokyaAPI url eulerClient "aarokya-generate-token" proxy
+
+callAarokyaAPI :: (MonadFlow m, HasRequestId r, MonadReader r m) => CallAPI' m r api res res
+callAarokyaAPI url eulerClient description proxy = do
+  callAPI url eulerClient description proxy
+    >>= fromEitherM (\err -> InternalError $ "Failed to call " <> description <> " API: " <> show err)

--- a/lib/mobility-core/src/Kernel/External/PartnerSdk/Aarokya/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/PartnerSdk/Aarokya/Types.hs
@@ -1,0 +1,24 @@
+module Kernel.External.PartnerSdk.Aarokya.Types where
+
+import Kernel.External.Encryption
+import Kernel.Prelude
+
+data AarokyaTokenRequest = AarokyaTokenRequest
+  { phone_country_code :: Text,
+    phone_number :: Text,
+    platform_id :: Text,
+    dl_number :: Maybe Text
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)
+
+newtype AarokyaTokenResponse = AarokyaTokenResponse
+  { access_token :: Text
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)
+
+data AarokyaSdkConfig = AarokyaSdkConfig
+  { url :: BaseUrl,
+    apiKey :: EncryptedField 'AsEncrypted Text,
+    platformId :: Text
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)

--- a/lib/mobility-core/src/Kernel/External/PartnerSdk/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/PartnerSdk/Interface.hs
@@ -1,0 +1,22 @@
+module Kernel.External.PartnerSdk.Interface
+  ( module Reexport,
+    module Kernel.External.PartnerSdk.Interface,
+  )
+where
+
+import qualified Kernel.External.PartnerSdk.Interface.Aarokya as Aarokya
+import Kernel.External.PartnerSdk.Interface.Types
+import Kernel.External.PartnerSdk.Types as Reexport
+import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
+import Kernel.Utils.Common
+
+generateToken ::
+  ( EncFlow m r,
+    CoreMetrics m,
+    HasRequestId r
+  ) =>
+  PartnerSdkConfig ->
+  GenerateTokenReq ->
+  m GenerateTokenResp
+generateToken serviceConfig req = case serviceConfig of
+  AarokyaPartnerSdkConfig cfg -> Aarokya.generateToken cfg req

--- a/lib/mobility-core/src/Kernel/External/PartnerSdk/Interface/Aarokya.hs
+++ b/lib/mobility-core/src/Kernel/External/PartnerSdk/Interface/Aarokya.hs
@@ -1,0 +1,39 @@
+module Kernel.External.PartnerSdk.Interface.Aarokya where
+
+import Kernel.External.Encryption
+import qualified Kernel.External.PartnerSdk.Aarokya.Flow as Aarokya
+import qualified Kernel.External.PartnerSdk.Aarokya.Types as AarokyaTypes
+import Kernel.External.PartnerSdk.Interface.Types
+import Kernel.Prelude
+import qualified Kernel.Tools.Metrics.CoreMetrics as Metrics
+import Kernel.Utils.Common
+
+generateToken ::
+  ( Metrics.CoreMetrics m,
+    EncFlow m r,
+    HasRequestId r,
+    MonadReader r m
+  ) =>
+  AarokyaTypes.AarokyaSdkConfig ->
+  GenerateTokenReq ->
+  m GenerateTokenResp
+generateToken config req = do
+  apiKey <- decrypt config.apiKey
+  let aarokyaReq = toAarokyaTokenRequest config req
+  resp <- Aarokya.generateToken config.url apiKey aarokyaReq
+  pure $ fromAarokyaTokenResponse resp
+
+toAarokyaTokenRequest :: AarokyaTypes.AarokyaSdkConfig -> GenerateTokenReq -> AarokyaTypes.AarokyaTokenRequest
+toAarokyaTokenRequest config req =
+  AarokyaTypes.AarokyaTokenRequest
+    { phone_country_code = req.phoneCountryCode,
+      phone_number = req.phoneNumber,
+      platform_id = config.platformId,
+      dl_number = req.dlNumber
+    }
+
+fromAarokyaTokenResponse :: AarokyaTypes.AarokyaTokenResponse -> GenerateTokenResp
+fromAarokyaTokenResponse resp =
+  GenerateTokenResp
+    { accessToken = resp.access_token
+    }

--- a/lib/mobility-core/src/Kernel/External/PartnerSdk/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/PartnerSdk/Interface/Types.hs
@@ -1,0 +1,20 @@
+module Kernel.External.PartnerSdk.Interface.Types where
+
+import qualified Kernel.External.PartnerSdk.Aarokya.Types as Aarokya
+import Kernel.Prelude
+
+data GenerateTokenReq = GenerateTokenReq
+  { phoneCountryCode :: Text,
+    phoneNumber :: Text,
+    dlNumber :: Maybe Text
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)
+
+newtype GenerateTokenResp = GenerateTokenResp
+  { accessToken :: Text
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)
+
+data PartnerSdkConfig
+  = AarokyaPartnerSdkConfig Aarokya.AarokyaSdkConfig
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)

--- a/lib/mobility-core/src/Kernel/External/PartnerSdk/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/PartnerSdk/Types.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Kernel.External.PartnerSdk.Types where
+
+import Data.Aeson.Types
+import EulerHS.Prelude
+import Kernel.Beam.Lib.UtilsTH (mkBeamInstancesForEnumAndList)
+import Kernel.Storage.Esqueleto (derivePersistField)
+
+data PartnerSdkService = Aarokya
+  deriving (Show, Read, Eq, Ord, Generic)
+
+$(mkBeamInstancesForEnumAndList ''PartnerSdkService)
+derivePersistField "PartnerSdkService"
+
+instance FromJSON PartnerSdkService where
+  parseJSON (String "Aarokya") = pure Aarokya
+  parseJSON (String _) = parseFail "Expected \"Aarokya\""
+  parseJSON e = typeMismatch "String" e
+
+instance ToJSON PartnerSdkService where
+  toJSON = String . show


### PR DESCRIPTION
## Type of Change                                                                                             
                                                                                                                
  - [ ] Bugfix                                                                                                  
  - [x] New feature                                                                                             
  - [ ] Enhancement
  - [ ] Refactoring
  - [ ] Dependency updates                                                                                      
  
  ## Description                                                                                                
                  
  Adds a new `PartnerSdk` external service category under `Kernel.External.PartnerSdk`, with **Aarokya** as the 
  first provider integration. This follows the existing provider pattern used elsewhere in `mobility-core`
  (abstract `Interface/` + provider-specific implementation).                                                   
                  
  Modules introduced:                                                                                           
  - `Kernel.External.PartnerSdk.Types` — `PartnerSdkService` enum (currently just `Aarokya`), with
  Beam/Persist/JSON instances.                                                                                  
  - `Kernel.External.PartnerSdk.Interface` + `Interface.Types` — provider-agnostic `PartnerSdkConfig` sum type,
  `GenerateTokenReq`/`GenerateTokenResp`, and a dispatching `generateToken`.                                    
  - `Kernel.External.PartnerSdk.Interface.Aarokya` — Aarokya-specific adapter that decrypts the API key and maps
   between generic and provider-specific request/response shapes.                                               
  - `Kernel.External.PartnerSdk.Aarokya.Flow` — Servant client for Aarokya's `POST /auth/token` endpoint.
  - `Kernel.External.PartnerSdk.Aarokya.Types` — `AarokyaTokenRequest`, `AarokyaTokenResponse`,                 
  `AarokyaSdkConfig` (URL + encrypted API key + platform ID).                                                   
                                                                                                                
  Consumer services (e.g., driver-offer-bpp) can now call `PartnerSdk.Interface.generateToken` to obtain an     
  Aarokya access token given a phone number and optional DL number.
                                                                                                                
  ## Additional Changes

  - [ ] This PR modifies the database schema (database migration added)                                         
  - [ ] This PR modifies dhall configs/environment variables
                                                                                                                
  Note: consuming services will need to add `AarokyaPartnerSdkConfig` to their config (URL, encrypted API key,  
  platform ID) when they adopt this integration — no config changes in this repo.                               
                                                                                                                
  ## Motivation and Context

  Introduces the shared-kernel plumbing required to integrate the Aarokya partner SDK (driver health/wellness   
  platform) across backend services. Kept as a generic `PartnerSdk` namespace so additional partner SDKs can be
  added behind the same interface without churning consumers.                                                   
                  
  ## How did you test it?

  - `cabal build` — compiles clean under `-Wall -Werror`.                                                       
  - Module registration verified in `mobility-core.cabal`.
  - End-to-end token generation will be exercised from the consuming service PR.                                
                                                                                                                
  ## Checklist                                                                                                  
                                                                                                                
  - [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`                            
  - [x] I reviewed submitted code
  - [ ] I added unit tests for my changes where possible                                                        
  - [ ] I added a CHANGELOG entry if applicable