### PR TITLE
aarokya-headerchanges

### DIFF
--- a/lib/mobility-core/src/Kernel/External/PartnerSdk/Aarokya/Flow.hs
+++ b/lib/mobility-core/src/Kernel/External/PartnerSdk/Aarokya/Flow.hs
@@ -11,7 +11,7 @@ import Servant hiding (throwError)
 type GenerateTokenAPI =
   "auth"
     :> "token"
-    :> Header "api-key" Text
+    :> Header "Authorization" Text
     :> ReqBody '[JSON] AarokyaTokenRequest
     :> Post '[JSON] AarokyaTokenResponse
 
@@ -21,9 +21,9 @@ generateToken ::
   Text ->
   AarokyaTokenRequest ->
   m AarokyaTokenResponse
-generateToken url apiKey request = do
+generateToken url basicToken request = do
   let proxy = Proxy @GenerateTokenAPI
-      eulerClient = Euler.client proxy (Just apiKey) request
+      eulerClient = Euler.client proxy (Just ("Basic " <> basicToken)) request
   callAarokyaAPI url eulerClient "aarokya-generate-token" proxy
 
 callAarokyaAPI :: (MonadFlow m, HasRequestId r, MonadReader r m) => CallAPI' m r api res res

--- a/lib/mobility-core/src/Kernel/External/PartnerSdk/Aarokya/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/PartnerSdk/Aarokya/Types.hs
@@ -3,11 +3,16 @@ module Kernel.External.PartnerSdk.Aarokya.Types where
 import Kernel.External.Encryption
 import Kernel.Prelude
 
+data AarokyaIdProof = AarokyaIdProof
+  { proof_type :: Text,
+    number :: Text
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)
+
 data AarokyaTokenRequest = AarokyaTokenRequest
   { phone_country_code :: Text,
     phone_number :: Text,
-    platform_id :: Text,
-    dl_number :: Maybe Text
+    id_proof :: AarokyaIdProof
   }
   deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
@@ -18,7 +23,6 @@ newtype AarokyaTokenResponse = AarokyaTokenResponse
 
 data AarokyaSdkConfig = AarokyaSdkConfig
   { url :: BaseUrl,
-    apiKey :: EncryptedField 'AsEncrypted Text,
-    platformId :: Text
+    basicToken :: EncryptedField 'AsEncrypted Text
   }
   deriving (Show, Eq, Generic, ToJSON, FromJSON)

--- a/lib/mobility-core/src/Kernel/External/PartnerSdk/Interface/Aarokya.hs
+++ b/lib/mobility-core/src/Kernel/External/PartnerSdk/Interface/Aarokya.hs
@@ -18,18 +18,24 @@ generateToken ::
   GenerateTokenReq ->
   m GenerateTokenResp
 generateToken config req = do
-  apiKey <- decrypt config.apiKey
-  let aarokyaReq = toAarokyaTokenRequest config req
-  resp <- Aarokya.generateToken config.url apiKey aarokyaReq
+  basicToken <- decrypt config.basicToken
+  let aarokyaReq = toAarokyaTokenRequest req
+  resp <- Aarokya.generateToken config.url basicToken aarokyaReq
   pure $ fromAarokyaTokenResponse resp
 
-toAarokyaTokenRequest :: AarokyaTypes.AarokyaSdkConfig -> GenerateTokenReq -> AarokyaTypes.AarokyaTokenRequest
-toAarokyaTokenRequest config req =
+toAarokyaTokenRequest :: GenerateTokenReq -> AarokyaTypes.AarokyaTokenRequest
+toAarokyaTokenRequest req =
   AarokyaTypes.AarokyaTokenRequest
     { phone_country_code = req.phoneCountryCode,
       phone_number = req.phoneNumber,
-      platform_id = config.platformId,
-      dl_number = req.dlNumber
+      id_proof = toAarokyaIdProof req.idProof
+    }
+
+toAarokyaIdProof :: IdProof -> AarokyaTypes.AarokyaIdProof
+toAarokyaIdProof p =
+  AarokyaTypes.AarokyaIdProof
+    { proof_type = p.proofType,
+      number = p.number
     }
 
 fromAarokyaTokenResponse :: AarokyaTypes.AarokyaTokenResponse -> GenerateTokenResp

--- a/lib/mobility-core/src/Kernel/External/PartnerSdk/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/PartnerSdk/Interface/Types.hs
@@ -3,10 +3,16 @@ module Kernel.External.PartnerSdk.Interface.Types where
 import qualified Kernel.External.PartnerSdk.Aarokya.Types as Aarokya
 import Kernel.Prelude
 
+data IdProof = IdProof
+  { proofType :: Text,
+    number :: Text
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)
+
 data GenerateTokenReq = GenerateTokenReq
   { phoneCountryCode :: Text,
     phoneNumber :: Text,
-    dlNumber :: Maybe Text
+    idProof :: IdProof
   }
   deriving (Show, Eq, Generic, ToJSON, FromJSON)
 


### PR DESCRIPTION
## Type of Change                                                                                               
                                                                                                                  
  - [ ] Bugfix    
  - [ ] New feature                                                                                               
  - [x] Enhancement
  - [ ] Refactoring
  - [ ] Dependency updates                                                                                        
   
  ## Description                                                                                                  
                  
  Updates the Aarokya partner SDK integration:                                                                    
   
  - **Auth header**: Switched from custom `api-key` header to standard `Authorization: Basic <token>`.            
  - **Config**: Replaced `apiKey` + `platformId` in `AarokyaSdkConfig` with a single encrypted `basicToken`.
  - **Request payload**: Replaced the flat `platform_id` + optional `dl_number` fields in `AarokyaTokenRequest`   
  with a structured `id_proof` object (`proof_type`, `number`).                                                   
  - **Interface**: Added a new `IdProof` type (`proofType`, `number`); `GenerateTokenReq` now takes `idProof`     
  instead of `dlNumber`. Mapping helpers (`toAarokyaTokenRequest`, `toAarokyaIdProof`) updated accordingly.       
                  
  ### Additional Changes                                                                                          
                  
  - [ ] This PR modifies the database schema (database migration added)                                           
  - [x] This PR modifies dhall configs/environment variables
                                                                                                                  
  ## Motivation and Context
                                                                                                                  
  The Aarokya partner API now expects standard HTTP Basic auth and a generalized `id_proof` object (so any        
  government ID can be passed, not just driving license). This change aligns the client with the updated upstream
  contract.                                                                                                       
                  
  > **Breaking for downstream services**: dhall configs must drop `apiKey` / `platformId` and add `basicToken`.   
  Callers of `GenerateTokenReq` must pass `idProof` instead of `dlNumber`.
                                                                                                                  
  ## How did you test it?

  <!-- TODO: fill in — e.g. verified token generation against Aarokya staging with Basic auth + id_proof payload  
  -->
                                                                                                                  
  ## Checklist    

  - [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
  - [x] I reviewed submitted code                                                                                 
  - [ ] I added unit tests for my changes where possible                                                          
  - [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable