### PR TITLE
refactor: Update secondaryRedisEnabled logic in setMeshConfig function

### DIFF
--- a/lib/mobility-core/src/Kernel/Beam/Functions.hs
+++ b/lib/mobility-core/src/Kernel/Beam/Functions.hs
@@ -188,7 +188,7 @@ setMeshConfig modelName mSchema meshConfig' = do
                 redisTtl = redisTtl',
                 tableShardModRange = tableShardModRange',
                 redisKeyPrefix = redisKeyPrefix',
-                secondaryRedisEnabled = secondaryEnabled
+                secondaryRedisEnabled = secondaryEnabled || tables'.enableAllTablesForSecondaryCloudRead == Just True
               }
 
 withUpdatedMeshConfig :: forall table m a. (L.MonadFlow m, HasCallStack, ModelMeta table) => Proxy table -> (MeshConfig -> m a) -> m a

--- a/lib/mobility-core/src/Kernel/Types/Common.hs
+++ b/lib/mobility-core/src/Kernel/Types/Common.hs
@@ -78,7 +78,8 @@ data Tables = Tables
     tableRedisKeyPrefix :: HM.HashMap Text Text,
     allTablesDisabled :: Maybe Bool,
     enableSecondaryCloudRead :: Maybe Bool,
-    tablesForSecondaryCloudRead :: Maybe [Text]
+    tablesForSecondaryCloudRead :: Maybe [Text],
+    enableAllTablesForSecondaryCloudRead :: Maybe Bool
   }
   deriving (Generic, Show, ToJSON, FromJSON, FromDhall)
 
@@ -95,7 +96,8 @@ defaultTableData =
       tableRedisKeyPrefix = HM.empty,
       allTablesDisabled = Just True,
       enableSecondaryCloudRead = Nothing,
-      tablesForSecondaryCloudRead = Nothing
+      tablesForSecondaryCloudRead = Nothing,
+      enableAllTablesForSecondaryCloudRead = Nothing
     }
 
 data KafkaProperties = KafkaProperties


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new configuration option to enable secondary cloud reads globally, providing an alternative to table-based allowlisting for managing secondary read operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->