### PR TITLE
backend/feat: Add PASS_RELATED FCM notification type

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Notification/FCM/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Notification/FCM/Types.hs
@@ -215,6 +215,7 @@ data FCMNotificationType
   | VEHICLE_INSPECTION
   | PICKUP_ZONE_REQUEST
   | PICKUP_ZONE_NO_SHOW
+  | PASS_RELATED
   deriving (Show, Eq, Read, Ord, Generic, ToJSON, FromJSON, ToJSONKey, FromJSONKey)
   deriving (PrettyShow) via Showable FCMNotificationType
 


### PR DESCRIPTION
## Summary
- Adds `PASS_RELATED` as a new variant of `FCMNotificationType` in `Kernel.External.Notification.FCM.Types` so consumers can dispatch FCM notifications related to passes.

## Test plan
- [ ] `cabal build` succeeds
- [ ] Downstream services consuming `FCMNotificationType` rebuild without changes (additive enum variant)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pass-related push notifications in the notification system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->