### PR TITLE
feat: Add support for asynchronous cluster MGET operations and new en…

### DIFF
--- a/lib/mobility-core/src/Kernel/Beam/Connection/EnvVars.hs
+++ b/lib/mobility-core/src/Kernel/Beam/Connection/EnvVars.hs
@@ -70,3 +70,8 @@ getRunInMasterLTSRedisCell :: IO Bool
 getRunInMasterLTSRedisCell = do
   envVal <- lookupEnv "RUN_IN_MASTER_LTS_REDIS_CELL"
   pure (fromMaybe False (readMaybe =<< envVal))
+
+getClusterMGetAsyncEnabled :: IO Bool
+getClusterMGetAsyncEnabled = do
+  envVal <- lookupEnv "CLUSTER_MGET_ASYNC_ENABLED"
+  pure (fromMaybe False (readMaybe =<< envVal))

--- a/lib/mobility-core/src/Kernel/Storage/Hedis/Queries.hs
+++ b/lib/mobility-core/src/Kernel/Storage/Hedis/Queries.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 {-
   Copyright 2022-23, Juspay India Pvt Ltd
 
@@ -19,19 +21,23 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import Data.Either (partitionEithers)
 import Data.Hashable (Hashable, hash)
+import qualified Data.IntMap.Strict as IntMap
 import qualified Data.List as DL
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import Data.String.Conversions
-import Data.Text hiding (chunksOf, concatMap, map, null)
+import Data.Text hiding (any, chunksOf, concat, concatMap, length, map, null, replicate, zip)
 import qualified Data.Text as T
 import qualified Data.Text as Text
+import qualified Data.Vector as V
+import Database.Redis (keyToSlot)
 import Database.Redis as Reexport (GeoBy (..), GeoFrom (..), Queued, Redis, RedisTx, Reply, TxResult (..))
 import qualified Database.Redis as Hedis
 import qualified Database.Redis.Cluster as Cluster
 import qualified EulerHS.Language as L
 import EulerHS.Prelude (whenLeft)
 import GHC.Records.Extra
-import Kernel.Beam.Connection.EnvVars (getRunInMasterCloudRedisCell, getRunInMasterLTSRedisCell)
+import Kernel.Beam.Connection.EnvVars (getClusterMGetAsyncEnabled, getRunInMasterCloudRedisCell, getRunInMasterLTSRedisCell)
 import Kernel.Prelude
 import Kernel.Storage.Hedis.Config
 import Kernel.Storage.Hedis.Error
@@ -364,6 +370,167 @@ get' key decodeErrHandler = getImpl decodeResult key
 safeGet ::
   (FromJSON a, HedisFlow m env, TryException m) => Text -> m (Maybe a)
 safeGet key = get' key (del key)
+
+-- | Internal: cluster MGET returning one Vector slot per input key, aligned
+-- by index. Hits → @Just bs@; misses, Redis errors, fork failures all → @Nothing@.
+-- Groups by hash slot (Cluster requires single-slot MGETs); when async is
+-- enabled, runs forks in capped chunks to bound parallelism.
+mGetClusterRaw ::
+  forall m env.
+  (HedisFlow m env, TryException m, L.MonadFlow m, Forkable m) =>
+  [Text] ->
+  m (V.Vector (Maybe BS.ByteString))
+mGetClusterRaw [] = pure V.empty
+mGetClusterRaw keys = withLogTag "CLUSTER" $ do
+  let !nKeys = length keys
+  prefKeys <- mapM buildKey keys
+  let !groups =
+        IntMap.elems $
+          IntMap.fromListWith
+            (<>)
+            [(fromEnum (keyToSlot pk), NE.singleton (i, pk)) | (i, pk) <- zip [0 ..] prefKeys]
+  asyncEnabled <- liftIO getClusterMGetAsyncEnabled
+  results <-
+    if asyncEnabled && length groups > 1
+      then concat <$> traverse runChunk (chunksOf clusterMGetForkLimit groups)
+      else traverse runGroup groups
+  pure $! V.replicate nKeys Nothing V.// concat results
+  where
+    runGroup :: NonEmpty (Int, BS.ByteString) -> m [(Int, Maybe BS.ByteString)]
+    runGroup grp = do
+      let (idxs, prefKs) = NE.unzip grp
+          missForGroup = map (,Nothing) (NE.toList idxs)
+      result <-
+        withTimeRedis "RedisCluster" "mget" $
+          withTryCatch "mGetCluster" $
+            runHedisEither $ Hedis.mget (NE.toList prefKs)
+      case result of
+        Left exc -> do
+          logTagError "ERROR_WHILE_MGET" $ "Cluster MGET threw: " <> show exc
+          pure missForGroup
+        Right (Left reply) -> do
+          logTagError "ERROR_WHILE_MGET" $ "Cluster MGET failed: " <> show reply
+          pure missForGroup
+        Right (Right listBS) ->
+          -- Defensive: tolerate a malformed Redis reply that disagrees on length.
+          let !padded = DL.take (NE.length grp) (listBS <> DL.repeat Nothing)
+           in pure $ DL.zip (NE.toList idxs) padded
+
+    runChunk :: [NonEmpty (Int, BS.ByteString)] -> m [[(Int, Maybe BS.ByteString)]]
+    runChunk chunk = do
+      awaitables <- forM (DL.zip [0 :: Int ..] chunk) $ \(j, grp) ->
+        (grp,) <$> awaitableFork ("mGetCluster:" <> show j) (runGroup grp)
+      forM awaitables $ \(grp, aw) -> do
+        res <- L.await Nothing aw
+        case res of
+          Right xs -> pure xs
+          Left err -> do
+            logTagError "ERROR_WHILE_MGET_FORK" $ "Concurrent fork failed: " <> show err
+            pure $ map ((,Nothing) . fst) (NE.toList grp)
+
+    chunksOf :: Int -> [a] -> [[a]]
+    chunksOf k = DL.unfoldr step
+      where
+        step [] = Nothing
+        step xs = Just (DL.splitAt k xs)
+
+-- | Cluster MGET returning just the decoded values that were found. No
+-- order guarantee on the output. Decode failures are logged and dropped.
+mGetCluster ::
+  (FromJSON a, HedisFlow m env, TryException m, L.MonadFlow m, Forkable m) =>
+  [Text] ->
+  m [a]
+mGetCluster keys = do
+  raw <- mGetClusterRaw keys
+  catMaybes . V.toList <$> V.mapM decodeBytesLogging raw
+
+-- | Cluster MGET returning (key, value) pairs in input-key order. Decode
+-- failures are logged (with the offending key) and dropped; the key is
+-- left in Redis for the writer to fix or overwrite.
+mGetClusterWithKeys ::
+  (FromJSON a, HedisFlow m env, TryException m, L.MonadFlow m, Forkable m) =>
+  [Text] ->
+  m [(Text, a)]
+mGetClusterWithKeys keys = do
+  raw <- mGetClusterRaw keys
+  catMaybes . V.toList
+    <$> V.zipWithM decodeKeyedPair (V.fromList keys) raw
+
+-- | Internal: standalone MGET returning a Vector aligned by input index.
+-- Hits → @Just bs@; misses and Redis errors → @Nothing@.
+mGetStandaloneRaw ::
+  (HedisFlow m env, TryException m) =>
+  [Text] ->
+  m (V.Vector (Maybe BS.ByteString))
+mGetStandaloneRaw [] = pure V.empty
+mGetStandaloneRaw keys = withLogTag "STANDALONE" $ do
+  let !nKeys = length keys
+  prefKeys <- mapM buildKey keys
+  result <-
+    withTimeRedis "RedisStandalone" "mget" $
+      withTryCatch "mGetStandalone" $
+        runHedisEither' $ Hedis.mget prefKeys
+  case result of
+    Left exc -> do
+      logTagError "ERROR_WHILE_MGET" $ "Standalone MGET threw: " <> show exc
+      pure $ V.replicate nKeys Nothing
+    Right (Left reply) -> do
+      logTagError "ERROR_WHILE_MGET" $ "Standalone MGET failed: " <> show reply
+      pure $ V.replicate nKeys Nothing
+    Right (Right listBS) ->
+      pure $ V.fromListN nKeys (DL.take nKeys (listBS <> DL.repeat Nothing))
+
+-- | Standalone MGET returning just the decoded values that were found.
+mGetStandalone :: (FromJSON a, HedisFlow m env, TryException m) => [Text] -> m [a]
+mGetStandalone keys = do
+  raw <- mGetStandaloneRaw keys
+  catMaybes . V.toList <$> V.mapM decodeBytesLogging raw
+
+-- | Standalone MGET returning (key, value) pairs in input-key order. Decode
+-- failures are logged (with the offending key) and dropped.
+mGetStandaloneWithKeys ::
+  (FromJSON a, HedisFlow m env, TryException m) =>
+  [Text] ->
+  m [(Text, a)]
+mGetStandaloneWithKeys keys = do
+  raw <- mGetStandaloneRaw keys
+  catMaybes . V.toList
+    <$> V.zipWithM decodeKeyedPair (V.fromList keys) raw
+
+-- | Decode raw bytes; on failure log and return Nothing. Used by the
+-- values-only paths where the key isn't tracked.
+decodeBytesLogging ::
+  (FromJSON a, HedisFlow m env, TryException m) =>
+  Maybe BS.ByteString ->
+  m (Maybe a)
+decodeBytesLogging Nothing = pure Nothing
+decodeBytesLogging (Just bs) = case Ae.eitherDecode (BSL.fromStrict bs) of
+  Right v -> pure (Just v)
+  Left e -> do
+    logTagError "REDIS" $ "MGet decode failure: " <> cs e
+    pure Nothing
+
+-- | Decode bytes paired with their originating key. On bad JSON, log with the
+-- key for traceability and drop the entry — does NOT delete the key from Redis.
+decodeKeyedPair ::
+  (FromJSON a, HedisFlow m env, TryException m) =>
+  Text ->
+  Maybe BS.ByteString ->
+  m (Maybe (Text, a))
+decodeKeyedPair _ Nothing = pure Nothing
+decodeKeyedPair k (Just bs) = case Ae.eitherDecode (BSL.fromStrict bs) of
+  Right v -> pure (Just (k, v))
+  Left e -> do
+    logTagError "REDIS" $ "MGet decode failure for key " <> k <> ": " <> cs e
+    pure Nothing
+
+decodeMGetResult ::
+  (FromJSON a, HedisFlow m env, TryException m) =>
+  Text ->
+  Maybe BS.ByteString ->
+  m (Maybe a)
+decodeMGetResult _ Nothing = pure Nothing
+decodeMGetResult key (Just bs) = decodeJSONWithErrorHandler key bs (del key)
 
 set ::
   (ToJSON a, HedisFlow m env, TryException m) => Text -> a -> m ()


### PR DESCRIPTION
…vironment variable retrieval function

- Introduced `getClusterMGetAsyncEnabled` to fetch the environment variable for enabling async MGET.
- Enhanced `mGetClusterRaw` to utilize the new async feature, allowing for improved performance with concurrent requests.
- Added internal logic to manage concurrent forks and limit the number of simultaneous operations.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
