### PR TITLE
backend/feat: add PASS_RELATED to Category enum (symmetry fix)

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Notification/Interface/FCM.hs
+++ b/lib/mobility-core/src/Kernel/External/Notification/Interface/FCM.hs
@@ -178,6 +178,7 @@ interfaceCategoryToFCMNotificationType = \case
   Interface.FEEDBACK_BADGE_PN -> FCM.FEEDBACK_BADGE_PN
   Interface.PICKUP_ZONE_REQUEST -> FCM.PICKUP_ZONE_REQUEST
   Interface.PICKUP_ZONE_NO_SHOW -> FCM.PICKUP_ZONE_NO_SHOW
+  Interface.PASS_RELATED -> FCM.PASS_RELATED
 
 interfaceShowNotificationToFCMShowNotification :: Interface.ShowNotification -> FCM.FCMShowNotification
 interfaceShowNotificationToFCMShowNotification = \case

--- a/lib/mobility-core/src/Kernel/External/Notification/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Notification/Interface/Types.hs
@@ -139,6 +139,7 @@ data Category
   | FEEDBACK_BADGE_PN
   | PICKUP_ZONE_REQUEST
   | PICKUP_ZONE_NO_SHOW
+  | PASS_RELATED
   deriving (Show, Eq, Read, Generic, Ord, ToSchema, ToJSON, FromJSON)
 
 $(mkBeamInstancesForEnum ''Category)


### PR DESCRIPTION
## Summary

Adds `PASS_RELATED` to the interface-level `Category` enum and the
`Category → FCMNotificationType` dispatch table. Pairs with #1266
which added `PASS_RELATED` only to the FCM-transport-level enum.

The `Category` enum is the type used by `NotificationReq.category`
and is the column type stored in `merchant_push_notification.fcm_notification_type`
on consumer side. Without this addition, rows written with
`fcm_notification_type = 'PASS_RELATED'` fail to decode into the
Haskell `Category` type at read time — `BeamRowReadError /
ColumnTypeMismatch / Could not 'read' "PASS_RELATED"` — and the
calling job is terminated by the scheduler.

## Test plan

- [ ] `cabal build all` in shared-kernel
- [ ] Bump nammayatri `flake.lock` to this rev
- [ ] Re-run `02-PassExpiryReminderMaster` integration test in nammayatri — verifies the `merchant_push_notification` lookup decodes cleanly and a `PASS_EXPIRY_REMINDER` FCM is sent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pass-related notifications in the notification system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->