### PR TITLE
Backend/fix: Add required app_id query param to Moengage Event API

### DIFF
--- a/lib/mobility-core/src/Kernel/External/EventTracking/Moengage/API.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Moengage/API.hs
@@ -25,6 +25,7 @@ import Servant
 type MoengageEventAPI =
   "v1" :> "event"
     :> Capture "app_id" Text
+    :> QueryParam' '[Required, Strict] "app_id" Text
     :> Header "Authorization" Text
     :> ReqBody '[JSON] MoengageEventReq
     :> Post '[JSON] MoengageEventResp

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Moengage/Flow.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Moengage/Flow.hs
@@ -50,7 +50,7 @@ pushEvent cfg req = do
       let authToken = buildBasicAuth cfg.appId apiSecret
           moengageClient = client (Proxy :: Proxy MoengageEventAPI)
       resp <-
-        callAPI cfg.baseUrl (moengageClient cfg.appId (Just authToken) req) "moengageEvent" moengageEventAPI
+        callAPI cfg.baseUrl (moengageClient cfg.appId cfg.appId (Just authToken) req) "moengageEvent" moengageEventAPI
           >>= fromEitherM (const $ InternalError "Failed to call Moengage Event API")
       pure (Just resp)
 


### PR DESCRIPTION
## Summary
Moengage S2S Event API requires \`app_id\` to appear **both** as a URL path segment AND as a query parameter:
\`\`\`
POST https://api-03.moengage.com/v1/event/<APP_ID>?app_id=<APP_ID>
\`\`\`

The current Servant type only had the path \`Capture\` — no \`QueryParam\` — so Moengage rejects the request, surfacing as a 4xx in rider-app's \`[event-tracking] event ... failed:\` log.

## Changes
- **API.hs**: Added \`QueryParam' '[Required, Strict] \"app_id\" Text\` between \`Capture\` and \`Header\`. Using \`Required, Strict\` instead of \`Maybe\` ensures the param is always sent (a missing \`Maybe\` would silently drop it and reproduce the bug).
- **Flow.hs**: Updated \`pushEvent\` call site to pass \`cfg.appId\` twice — once for the path \`Capture\` and once for the new query param.

No changes to \`MoengageCfg\`, the request body, auth header, or the \`enabled\` short-circuit.

## Test plan
- [ ] Verify \`cabal build mobility-core\` compiles
- [ ] Test against Moengage with real credentials — expect 200 instead of 4xx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Moengage event tracking integration to include required parameters in API requests, ensuring compliance with current API specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->