### PR TITLE
backend/fix: consume payouts_enabled field

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Stripe.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Stripe.hs
@@ -43,6 +43,7 @@ createConnectAccount config req = do
   accountResp <- Stripe.createAccount url apiKey accountReq
   let accountId = accountResp.id
   let chargesEnabled = accountResp.charges_enabled
+  let payoutsEnabled = accountResp.payouts_enabled
   let detailsSubmitted = accountResp.details_submitted
   when (req.businessType == Just Stripe.Company) $ do
     let personReq =
@@ -174,6 +175,7 @@ getAccount config accountId = do
   apiKey <- decrypt config.apiKey
   accountResp <- Stripe.getAccount url apiKey accountId
   let chargesEnabled = accountResp.charges_enabled
+  let payoutsEnabled = accountResp.payouts_enabled
   let detailsSubmitted = accountResp.details_submitted
   let requirements = toRequirementsInfo <$> accountResp.requirements
   let futureRequirements = toRequirementsInfo <$> accountResp.future_requirements

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
@@ -755,6 +755,7 @@ data ConnectAccountLinkResp = ConnectAccountLinkResp
     accountUrl :: Text,
     accountUrlExpiry :: UTCTime,
     chargesEnabled :: Bool,
+    payoutsEnabled :: Bool,
     detailsSubmitted :: Bool
   }
   deriving stock (Show, Eq, Generic)
@@ -791,6 +792,7 @@ data RequirementsInfo = RequirementsInfo
 data ConnectAccountStatusResp = ConnectAccountStatusResp
   { accountId :: AccountId,
     chargesEnabled :: Bool,
+    payoutsEnabled :: Bool,
     detailsSubmitted :: Bool,
     requirements :: Maybe RequirementsInfo,
     futureRequirements :: Maybe RequirementsInfo

--- a/lib/mobility-core/src/Kernel/External/Payment/Stripe/Types/Accounts.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Stripe/Types/Accounts.hs
@@ -446,6 +446,7 @@ data AccountResp = AccountResp
   { id :: AccountId,
     _object :: Text,
     charges_enabled :: Bool,
+    payouts_enabled :: Bool,
     details_submitted :: Bool,
     requirements :: Maybe Requirements,
     future_requirements :: Maybe Requirements
@@ -458,7 +459,6 @@ data AccountResp = AccountResp
     -- external_accounts :: ExternalAccounts,
     -- individual :: IndividualDetails,
     -- metadata :: Metadata,
-    -- payouts_enabled :: Bool,
     -- settings :: Settings,
     -- tos_acceptance :: TosAcceptance,
     -- type :: AccountType


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Stripe account integration to track payout enablement status
  * Connected accounts now display whether payouts are enabled, providing improved visibility into account capabilities and management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->