### PR TITLE
Backend/fix: Add Beam/PersistField instances for EventTrackingService

### DIFF
--- a/lib/mobility-core/src/Kernel/External/EventTracking/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Types.hs
@@ -12,6 +12,7 @@
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Kernel.External.EventTracking.Types
   ( EventTrackingService (..),
@@ -20,7 +21,10 @@ module Kernel.External.EventTracking.Types
 where
 
 import Data.Aeson
+import Database.Beam.Backend
+import Kernel.Beam.Lib.UtilsTH (mkBeamInstancesForList)
 import Kernel.Prelude
+import Kernel.Storage.Esqueleto (derivePersistField)
 
 -- | Enum of event tracking service providers
 data EventTrackingService
@@ -30,3 +34,10 @@ data EventTrackingService
 -- | List of all available event tracking services
 availableEventTrackingServices :: [EventTrackingService]
 availableEventTrackingServices = [Moengage]
+
+instance (HasSqlValueSyntax be String) => HasSqlValueSyntax be EventTrackingService where
+  sqlValueSyntax = autoSqlValueSyntax
+
+$(mkBeamInstancesForList ''EventTrackingService)
+
+derivePersistField "EventTrackingService"


### PR DESCRIPTION
## Summary
The nammayatri rider-app is making `EventTrackingService` a column in `merchant_service_usage_config` (stored as a Postgres `TEXT[]`). Storing the value via Beam needs three typeclass instances on `EventTrackingService` that every other service-name enum in shared-kernel already has — see `SmsService` and `WhatsappService` for the pattern.

Without these instances, the Beam-generated table for the consumer fails to compile with:
```
No instance for HasSqlValueSyntax ... Kernel.External.EventTracking.EventTrackingService
arising from a use of 'Sequelize.SQLObject.convertToSQLObject'
```

The nammayatri side currently works around this by adding the instances to its project-internal `Domain.Types.UtilsTH` module — they should live next to the type in shared-kernel.

## Changes
Single file: `lib/mobility-core/src/Kernel/External/EventTracking/Types.hs`
- Added `{-# LANGUAGE TemplateHaskell #-}` pragma
- Added imports: `Database.Beam.Backend`, `Kernel.Beam.Lib.UtilsTH (mkBeamInstancesForList)`, `Kernel.Storage.Esqueleto (derivePersistField)`
- Added instance: `HasSqlValueSyntax be EventTrackingService`
- Added: `mkBeamInstancesForList ''EventTrackingService`
- Added: `derivePersistField "EventTrackingService"`

Pattern mirrored exactly from `SmsService` in `Kernel/External/SMS/Types.hs`.

## Test plan
- [ ] Verify `cabal build mobility-core` compiles clean
- [ ] Once merged, the rider-app PR can drop its workaround in `Domain.Types.UtilsTH`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database persistence infrastructure for event tracking, enabling improved data storage and SQL compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->