### PR TITLE
fix: removed hardcoded nothing for payment_method_type, payment_method and resp in txn of juspay transaction webhook

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
@@ -681,11 +681,23 @@ mkWebhookOrderStatusResp now (eventName, Juspay.OrderAndNotificationStatusConten
           txnId = Just justTransaction.txn_id,
           transactionStatusId = fromMaybe (-3001) justTransaction.status_id,
           transactionStatus = justTransaction.status,
-          paymentMethodType = Nothing,
-          paymentMethod = Nothing,
-          paymentGatewayResponse = Nothing,
-          respMessage = Nothing,
-          respCode = Nothing,
+          paymentMethodType = justTransaction.payment_method_type,
+          paymentMethod = justTransaction.payment_method,
+          paymentGatewayResponse =
+            justTransaction.payment_gateway_response
+              <&> ( \pgResp ->
+                      PaymentGatewayResponse
+                        { respCode = pgResp.resp_code,
+                          rrn = pgResp.rrn,
+                          created = pgResp.created,
+                          epgTxnId = pgResp.epg_txn_id,
+                          respMessage = pgResp.resp_message,
+                          authIdCode = pgResp.auth_id_code,
+                          txnId = pgResp.txn_id
+                        }
+                  ),
+          respMessage = justTransaction.payment_gateway_response >>= (.resp_message),
+          respCode = justTransaction.payment_gateway_response >>= (.resp_code),
           gatewayReferenceId = Nothing,
           bankErrorMessage = if justTransaction.error_message == Just "" then Nothing else justTransaction.error_message,
           bankErrorCode = if justTransaction.error_code == Just "" then Nothing else justTransaction.error_code,

--- a/lib/mobility-core/src/Kernel/External/Payment/Juspay/Types/Webhook.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Juspay/Types/Webhook.hs
@@ -89,7 +89,10 @@ data WebhookTxnData = WebhookTxnData
     payer_vpa :: Maybe Text,
     upi :: Maybe Upi,
     card :: Maybe CardInfo,
-    txn_detail :: Maybe TxnDetail
+    txn_detail :: Maybe TxnDetail,
+    payment_method_type :: Maybe Text,
+    payment_method :: Maybe Text,
+    payment_gateway_response :: Maybe PaymentGatewayResponse
   }
   deriving stock (Show, Generic)
   deriving anyclass (FromJSON, ToJSON, ToSchema)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Payment webhook processing now captures comprehensive transaction data including payment method type, payment method information, and payment gateway response details for improved visibility into transaction handling.

* **Bug Fixes**
  * Improved transaction status response handling to properly populate gateway-specific information including response codes and payment method details in webhook data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->