### PR TITLE
Added middleName regex

### DIFF
--- a/lib/mobility-core/src/Kernel/Utils/Predicates.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Predicates.hs
@@ -105,3 +105,6 @@ email = LengthInRange 5 254 `And` (localPart <> "@" <> domain)
 
 vehicleRegistrationCertNumberRule :: LengthInRange `And` Regex
 vehicleRegistrationCertNumberRule = LengthInRange 5 12 `And` star certNumber
+
+middleName :: Regex
+middleName = name \/ ""

--- a/lib/mobility-core/test/src/Predicates.hs
+++ b/lib/mobility-core/test/src/Predicates.hs
@@ -29,7 +29,9 @@ predicatesTests =
   testGroup
     "Kernel.Utils.Predicates"
     [ namePredicateTests,
-      nameValidateFieldTests
+      middleNamePredicateTests,
+      nameValidateFieldTests,
+      middleNameValidateFieldTests
     ]
 
 namePredicateTests :: TestTree
@@ -77,6 +79,52 @@ namePredicateTests =
       testCase (T.unpack label) $
         assertBool ("expected invalid: " <> T.unpack label) (not (pFun P.name t))
 
+middleNamePredicateTests :: TestTree
+middleNamePredicateTests =
+  testGroup
+    "P.middleName (Text)"
+    [ testGroup
+        "valid"
+        $ map
+          (uncurry validCase)
+          [ ("empty", ""),
+            ("Mohammed", "Mohammed"),
+            ("Al-GBURI", "Al-GBURI"),
+            ("O'Connor", "O'Connor"),
+            ("Jean Paul", "Jean Paul"),
+            ("Jean-Paul", "Jean-Paul"),
+            ("D'Arcy", "D'Arcy"),
+            ("A B", "A B"),
+            ("A-B-C", "A-B-C")
+          ],
+      testGroup
+        "invalid"
+        $ map
+          (uncurry invalidCase)
+          [ ("only space", " "),
+            ("leading hyphen", "-A"),
+            ("trailing hyphen", "A-"),
+            ("double hyphen", "A--B"),
+            ("double apostrophe", "A''B"),
+            ("double space", "A  B"),
+            ("underscore", "A_B"),
+            ("dot", "A.B"),
+            ("digit", "A1"),
+            ("trailing space", "Al-GBURI "),
+            ("leading space", " Al"),
+            ("double space only", "  ")
+          ]
+    ]
+  where
+    validCase :: Text -> Text -> TestTree
+    validCase label t =
+      testCase (T.unpack label) $
+        assertBool ("expected valid: " <> T.unpack label) (pFun P.middleName t)
+    invalidCase :: Text -> Text -> TestTree
+    invalidCase label t =
+      testCase (T.unpack label) $
+        assertBool ("expected invalid: " <> T.unpack label) (not (pFun P.middleName t))
+
 nameValidateFieldTests :: TestTree
 nameValidateFieldTests =
   testGroup
@@ -104,5 +152,51 @@ nameValidateFieldTests =
           V.Success () -> assertFailure "expected validation failure"
           V.Failure [ValidationDescription {fieldName = ["fullName"], expectation}] ->
             expectation @=? pShow (InMaybe P.name) "fullName"
+          V.Failure errs -> assertFailure $ "unexpected failures: " <> show errs
+    ]
+
+middleNameValidateFieldTests :: TestTree
+middleNameValidateFieldTests =
+  testGroup
+    "P.middleName via validateField / InMaybe"
+    [ testCase "validateField accepts empty Text" $
+        case validateField "middleName" ("" :: Text) P.middleName of
+          V.Success () -> pure ()
+          V.Failure errs -> assertFailure $ "unexpected failure: " <> show errs,
+      testCase "validateField rejects single space" $
+        case validateField "middleName" (" " :: Text) P.middleName of
+          V.Success () -> assertFailure "expected validation failure"
+          V.Failure [ValidationDescription {fieldName = ["middleName"], expectation}] ->
+            expectation @=? pShow P.middleName "middleName"
+          V.Failure errs -> assertFailure $ "unexpected failures: " <> show errs,
+      testCase "validateField accepts valid name Text" $
+        case validateField "middleName" ("Jean-Paul" :: Text) P.middleName of
+          V.Success () -> pure ()
+          V.Failure errs -> assertFailure $ "unexpected failure: " <> show errs,
+      testCase "validateField rejects invalid Text" $
+        case validateField "middleName" ("A--B" :: Text) P.middleName of
+          V.Success () -> assertFailure "expected validation failure"
+          V.Failure [ValidationDescription {fieldName = ["middleName"], expectation}] ->
+            expectation @=? pShow P.middleName "middleName"
+          V.Failure errs -> assertFailure $ "unexpected failures: " <> show errs,
+      testCase "InMaybe: Nothing passes" $
+        case validateField "middleName" (Nothing :: Maybe Text) (InMaybe P.middleName) of
+          V.Success () -> pure ()
+          V.Failure errs -> assertFailure $ "unexpected failure: " <> show errs,
+      testCase "InMaybe: Just empty passes" $
+        case validateField "middleName" (Just ("" :: Text)) (InMaybe P.middleName) of
+          V.Success () -> pure ()
+          V.Failure errs -> assertFailure $ "unexpected failure: " <> show errs,
+      testCase "InMaybe: Just single space fails" $
+        case validateField "middleName" (Just (" " :: Text)) (InMaybe P.middleName) of
+          V.Success () -> assertFailure "expected validation failure"
+          V.Failure [ValidationDescription {fieldName = ["middleName"], expectation}] ->
+            expectation @=? pShow (InMaybe P.middleName) "middleName"
+          V.Failure errs -> assertFailure $ "unexpected failures: " <> show errs,
+      testCase "InMaybe: Just invalid fails" $
+        case validateField "middleName" (Just ("A1" :: Text)) (InMaybe P.middleName) of
+          V.Success () -> assertFailure "expected validation failure"
+          V.Failure [ValidationDescription {fieldName = ["middleName"], expectation}] ->
+            expectation @=? pShow (InMaybe P.middleName) "middleName"
           V.Failure errs -> assertFailure $ "unexpected failures: " <> show errs
     ]


### PR DESCRIPTION
## Type of Change
Enhancement

- [ ] Bugfix
- [ ] New feature
- [ x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
Added middleName regex


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<img width="694" height="692" alt="Screenshot 2026-05-21 at 7 25 28 PM" src="https://github.com/user-attachments/assets/cc370b9f-8e4b-4fc3-9eed-3a274fbf5958" />


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added middle-name validation that accepts ASCII-only names or an empty string (whitespace-only values are rejected).

* **Tests**
  * Added tests for the middle-name predicate and field validation, covering accepted and rejected inputs (including empty string allowed and single-space rejected) and validation error outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/shared-kernel/pull/1302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->