### PR TITLE
backend/feat: round amounts by currency precision in roundAmountByCurrency

### DIFF
--- a/lib/mobility-core/src/Kernel/Types/Price.hs
+++ b/lib/mobility-core/src/Kernel/Types/Price.hs
@@ -172,8 +172,7 @@ instance ToJSON PriceAPIEntity where
       ]
 
 roundAmountByCurrency :: Currency -> HighPrecMoney -> HighPrecMoney
-roundAmountByCurrency EUR amount = roundHighPrecMoney @HighPrecMoney (getAccuracy EUR) amount
-roundAmountByCurrency _ amount = amount -- for backward compatibility
+roundAmountByCurrency = roundAmountByCurrency'
 
 mkPriceAPIEntity :: Price -> PriceAPIEntity
 mkPriceAPIEntity Price {..} = PriceAPIEntity {..}


### PR DESCRIPTION
## Summary

- `roundAmountByCurrency` was only rounding EUR amounts; INR and USD were passed through unchanged (backward-compat stub)
- Now delegates to `roundAmountByCurrency'` which applies `getAccuracy` for every currency:
  - INR → 0 decimal places
  - USD → 2 decimal places
  - EUR → 2 decimal places

## Test plan

- [ ] Verify `roundAmountByCurrency INR (HighPrecMoney 123.456)` → `123` (rounded to integer)
- [ ] Verify `roundAmountByCurrency USD (HighPrecMoney 10.3333)` → `10.33`
- [ ] Verify `roundAmountByCurrency EUR (HighPrecMoney 10.3333)` → `10.33` (unchanged behaviour)
- [ ] Ensure existing callers that rely on `roundAmountByCurrency` (e.g. `PriceAPIEntity` JSON serialisation) still produce correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed currency amount rounding to apply consistently across all currencies based on their configured decimal accuracy, rather than only rounding EUR amounts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/shared-kernel/pull/1308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->