### PR TITLE
backend/enhancement:- Added sos media supoort for Zendesk

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Ticket/Interface/Zendesk.hs
+++ b/lib/mobility-core/src/Kernel/External/Ticket/Interface/Zendesk.hs
@@ -27,6 +27,7 @@ import qualified Kernel.External.Ticket.Zendesk.Types as Zendesk
 import Kernel.Prelude
 import qualified Kernel.Tools.Metrics.CoreMetrics as Metrics
 import Kernel.Utils.Servant.Client
+import Kernel.Utils.Time (showTimeIst)
 
 createTicket ::
   ( Metrics.CoreMetrics m,
@@ -53,7 +54,11 @@ mkZendeskCreateTicketReq cfg IT.CreateTicketReq {..} =
     { ticket =
         Zendesk.ZendeskTicketBody
           { subject = buildSubject category rideDescription,
-            comment = Zendesk.ZendeskComment {body = buildBody issueDescription name phoneNo rideDescription mediaFiles},
+            comment =
+              Zendesk.ZendeskComment
+                { body = buildBody issueDescription name phoneNo rideDescription mediaFiles,
+                  htmlBody = buildHtmlBody issueDescription name phoneNo rideDescription mediaFiles
+                },
             requester = Just $ Zendesk.ZendeskRequester {name = fromMaybe "Unknown" name, email = cfg.requesterEmail},
             organizationId = cfg.organizationId,
             groupId = cfg.groupId,
@@ -89,6 +94,56 @@ formatMediaFiles (Just []) = ""
 formatMediaFiles (Just urls) =
   T.unlines $ ["", "=== Recording / Media ==="] ++ map (\u -> "- " <> u) urls
 
+formatMediaFilesHtml :: Maybe [Text] -> Text
+formatMediaFilesHtml Nothing = ""
+formatMediaFilesHtml (Just []) = ""
+formatMediaFilesHtml (Just urls) =
+  "<br><strong>Recording / Media</strong><ul>"
+    <> T.concat (map (\u -> "<li><a href=\"" <> u <> "\">" <> extractLabel u <> "</a></li>") urls)
+    <> "</ul>"
+  where
+    extractLabel url
+      | "/rides/" `T.isInfixOf` url = "View Ride"
+      | "/sos/" `T.isInfixOf` url = "View SOS Media"
+      | otherwise =
+        let withoutQuery = T.takeWhile (/= '?') url
+            parts = T.splitOn "/" withoutQuery
+         in case filter (not . T.null) parts of
+              [] -> url
+              ps -> last ps
+
+htmlEscape :: Text -> Text
+htmlEscape =
+  T.replace "&" "&amp;"
+    . T.replace "<" "&lt;"
+    . T.replace ">" "&gt;"
+    . T.replace "\"" "&quot;"
+    . T.replace "'" "&#39;"
+
+-- html_body is only set when media files are present.
+-- It wraps the plain-text body in a <pre> tag (preserving formatting) and
+-- appends the media links as proper HTML anchors.
+-- Zendesk shows html_body in the agent UI and falls back to body elsewhere,
+-- so agents see exactly one copy of the content.
+buildHtmlBody :: Text -> Maybe Text -> Maybe Text -> Maybe IT.RideInfo -> Maybe [Text] -> Maybe Text
+buildHtmlBody issueDescription mbName mbPhone mbRide mbMediaFiles =
+  case formatMediaFilesHtml mbMediaFiles of
+    "" -> Nothing
+    mediaHtml ->
+      Just $
+        "<pre>" <> htmlEscape (buildBody issueDescription mbName mbPhone mbRide Nothing) <> "</pre>"
+          <> mediaHtml
+
+buildHtmlUpdateBody :: Text -> Maybe IT.RideInfo -> Maybe IT.UpdateIssueDetails -> Maybe Text
+buildHtmlUpdateBody comment mbRide mbIssueDetails =
+  let mediaHtml = maybe "" (formatMediaFilesHtml . (.mediaFiles)) mbIssueDetails
+   in case mediaHtml of
+        "" -> Nothing
+        html ->
+          Just $
+            "<pre>" <> htmlEscape (buildUpdateBody comment mbRide (fmap (\d -> (d :: IT.UpdateIssueDetails) {IT.mediaFiles = Nothing}) mbIssueDetails)) <> "</pre>"
+              <> html
+
 formatRideInfo :: IT.RideInfo -> Text
 formatRideInfo IT.RideInfo {..}
   | T.null rideShortId = ""
@@ -101,6 +156,8 @@ formatRideInfo IT.RideInfo {..}
           Just $ "City: " <> rideCity,
           Just $ "Status: " <> status,
           Just $ "Vehicle: " <> vehicleNo,
+          Just $ "Vehicle Category: " <> fromMaybe "N/A" vehicleCategory,
+          Just $ "Created At: " <> showTimeIst rideCreatedAt,
           (\f -> "Fare: " <> show f) <$> fare,
           Just "",
           Just "=== Driver ===",
@@ -155,7 +212,12 @@ mkZendeskUpdateTicketReq IT.UpdateTicketReq {..} =
   Zendesk.ZendeskUpdateTicketReq
     { ticket =
         Zendesk.ZendeskUpdateTicketBody
-          { comment = Just $ Zendesk.ZendeskComment {body = buildUpdateBody comment rideDescription issueDetails},
+          { comment =
+              Just
+                Zendesk.ZendeskComment
+                  { body = buildUpdateBody comment rideDescription issueDetails,
+                    htmlBody = buildHtmlUpdateBody comment rideDescription issueDetails
+                  },
             status = Just $ ticketStatusToZendesk status
           }
     }

--- a/lib/mobility-core/src/Kernel/External/Ticket/Zendesk/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Ticket/Zendesk/Types.hs
@@ -65,11 +65,23 @@ instance FromJSON ZendeskTicketBody where
       <*> v .: "type"
       <*> (v .:? "custom_fields" .!= [])
 
-newtype ZendeskComment = ZendeskComment
-  { body :: Text
+data ZendeskComment = ZendeskComment
+  { body :: Text,
+    htmlBody :: Maybe Text
   }
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (ToJSON, FromJSON)
+
+instance ToJSON ZendeskComment where
+  toJSON ZendeskComment {..} =
+    object $
+      ["body" .= body]
+        ++ maybe [] (\h -> ["html_body" .= h]) htmlBody
+
+instance FromJSON ZendeskComment where
+  parseJSON = withObject "ZendeskComment" $ \v ->
+    ZendeskComment
+      <$> v .: "body"
+      <*> v .:? "html_body"
 
 data ZendeskRequester = ZendeskRequester
   { name :: Text,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zendesk tickets now include optional HTML content alongside plain text for richer formatting.
  * Plain-text bodies are HTML-escaped and wrapped for consistent display; media is suppressed inside the preformatted block.
  * An HTML “Recording / Media” section is appended only when media exists; media links render as labeled anchors.
  * Ticket entries now show Vehicle Category and a Created At timestamp in IST.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/shared-kernel/pull/1312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->