### PR TITLE
feat: add GFieldNames to BeamTable for jsonb-fallback override support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,6 +357,11 @@
           "common",
           "flake-parts"
         ],
+        "flake-root": [
+          "euler-hs",
+          "common",
+          "flake-root"
+        ],
         "haskell-flake": [
           "haskell-flake"
         ],
@@ -365,16 +370,28 @@
         "nixpkgs": [
           "nixpkgs"
         ],
+        "nixpkgs-140774-workaround": "nixpkgs-140774-workaround_3",
+        "nixpkgs-21_11": "nixpkgs-21_11_3",
+        "pre-commit-hooks-nix": [
+          "euler-hs",
+          "common",
+          "pre-commit-hooks-nix"
+        ],
         "sequelize": "sequelize",
         "servant-mock": "servant-mock",
-        "tinylog": "tinylog"
+        "tinylog": "tinylog",
+        "treefmt-nix": [
+          "euler-hs",
+          "common",
+          "treefmt-nix"
+        ]
       },
       "locked": {
-        "lastModified": 1774254079,
-        "narHash": "sha256-FU9xn2nlxbJ1CF/cH/7HNjV5/JGvkInMGyOJRzQX9Ck=",
+        "lastModified": 1780053081,
+        "narHash": "sha256-G06HWQujmStsahtXo0H2a5VtlWIxm3vgoo6FkZ0oGrk=",
         "owner": "nammayatri",
         "repo": "euler-hs",
-        "rev": "bf99af696dca8d9c221e45b2715cf45a827b4fef",
+        "rev": "377d3756de55eb8cd16d10adb1142c9f7875769c",
         "type": "github"
       },
       "original": {
@@ -1069,6 +1086,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-140774-workaround_3": {
+      "locked": {
+        "lastModified": 1681394207,
+        "narHash": "sha256-hk9RUPnChwKjCtm/YzixAak5wIzIw+b1avp7I3vg3dQ=",
+        "owner": "srid",
+        "repo": "nixpkgs-140774-workaround",
+        "rev": "a3c6d0622758e5d3da3d63100547f400ce6cb376",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "nixpkgs-140774-workaround",
+        "type": "github"
+      }
+    },
     "nixpkgs-21_11": {
       "locked": {
         "lastModified": 1659446231,
@@ -1086,6 +1118,22 @@
       }
     },
     "nixpkgs-21_11_2": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-21_11_3": {
       "locked": {
         "lastModified": 1659446231,
         "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",

--- a/lib/mobility-core/src/Kernel/Beam/Functions.hs
+++ b/lib/mobility-core/src/Kernel/Beam/Functions.hs
@@ -50,11 +50,13 @@ import Database.Beam hiding (timestamp)
 import Database.Beam.MySQL ()
 import Database.Beam.Postgres
 import EulerHS.Extra.Monitoring.Types (UseMasterRedis (..))
+import EulerHS.JsonbFallback (GFieldNames)
 import qualified EulerHS.KVConnector.Flow as KV
 import EulerHS.KVConnector.Types (KVConnector (..), MeshConfig (..), MeshMeta, TableMappings)
 import EulerHS.KVConnector.Utils
 import qualified EulerHS.Language as L
 import EulerHS.Types hiding (Log, V1)
+import GHC.Generics (Rep)
 import Kernel.Beam.Lib.Utils
 import Kernel.Beam.Types hiding (Tables)
 import qualified Kernel.Beam.Types as KBT
@@ -295,6 +297,7 @@ type BeamTable table =
     ToJSON (table Identity),
     TableMappings (table Identity),
     Serialize.Serialize (table Identity),
+    GFieldNames (Rep (table Identity)),
     Show (table Identity)
   )
 


### PR DESCRIPTION
## Summary

Adds `GFieldNames (Rep (table Identity))` to the `BeamTable` constraint synonym in `Kernel.Beam.Functions`, and bumps euler-hs in `flake.lock` to the revision that exports `GFieldNames`.

## Why

euler-hs's jsonb-fallback (auto-retry on Postgres `42703 column does not exist` via `SELECT to_jsonb(t.*)`) gained `mkTableInstancesWithTModifier` field-override support. Its `OVERLAPPING TryJsonbFallback BP.Pg BP.Postgres` instance now carries a `GFieldNames (Rep (table Identity))` constraint — used to map DB column names back to Haskell record-selector names so override fields (e.g. rider-app `Estimate.oldNightShiftCharge ↔ night_shift_multiplier`) decode correctly on fallback.

The KV-connector wrappers here (`findAllInternal` / `updateInternal` / `deleteInternal`) call the KV functions at **concrete** `Postgres` types, forcing resolution of that OVERLAPPING instance and propagating its `GFieldNames` constraint into `BeamTable`. Without this, mobility-core fails to build:

```
src/Kernel/Beam/Functions.hs:661:13: error:
    • Could not deduce (EulerHS.JsonbFallback.GFieldNames
                          (GHC.Generics.Rep (table Identity)))
        arising from a use of ‘KV.findAllWithKVConnector’
```

## What changes

- `import EulerHS.JsonbFallback (GFieldNames)` + `import GHC.Generics (Rep)`
- one line in the `BeamTable` synonym: `GFieldNames (Rep (table Identity)),`
- `flake.lock`: euler-hs → rev exporting `GFieldNames`

**No Template Haskell, no new instances, no per-table changes.** `GFieldNames` is a structural GHC.Generics class (`U1`/`M1 S`/`:*:`/`M1 D`/`M1 C`) that resolves automatically for every beam table's `Rep`. `Generic (table Identity)` is already provided by `Model`. All ~600 tables satisfy it for free.

## Test plan

- [x] `nix develop -c cabal build mobility-core` — links cleanly, all executables built
- [x] `Kernel.Beam.Functions` (the 3 previously-failing functions) compiles
- [ ] Downstream: bump `Backend/flake.lock` to this shared-kernel rev; Backend should build unchanged (concrete tables auto-satisfy the constraint)

## Dependency

Requires euler-hs PR #59 (exports `GFieldNames`) — already pinned in this `flake.lock`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened internal database table conversion infrastructure with enhanced field-name support to improve system reliability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nammayatri/shared-kernel/pull/1315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->