### PR TITLE
payment/feat: add Stripe card details to Charge webhook type and interface

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Events/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Events/Types.hs
@@ -147,6 +147,17 @@ data PaymentIntent = PaymentIntent
   deriving stock (Show)
 
 --- Charge Object ---
+data CardDetails = CardDetails
+  { brand :: Text,
+    country :: Maybe Text,
+    expMonth :: Int,
+    expYear :: Int,
+    fingerprint :: Maybe Text,
+    funding :: Maybe Text,
+    last4 :: Text
+  }
+  deriving stock (Show)
+
 data Charge = Charge
   { chargeId :: Stripe.ChargeId,
     paymentIntentId :: Maybe Stripe.PaymentIntentId,
@@ -159,6 +170,7 @@ data Charge = Charge
     balanceTransaction :: Maybe Text,
     calculatedStatementDescriptor :: Maybe Text,
     captured :: Bool,
+    cardDetails :: Maybe CardDetails,
     createdAt :: UTCTime,
     currency :: Currency,
     customer :: Maybe Stripe.CustomerId,

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Stripe.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Stripe.hs
@@ -701,6 +701,7 @@ mkChargeObject Stripe.Charge {..} =
       applicationFeeAmount = centsToUsd <$> application_fee_amount,
       balanceTransaction = balance_transaction,
       calculatedStatementDescriptor = calculated_statement_descriptor,
+      cardDetails = payment_method_details >>= (.card) <&> mkCardDetails,
       createdAt = posixSecondsToUTCTime created,
       failureCode = failure_code,
       failureMessage = failure_message,
@@ -709,6 +710,14 @@ mkChargeObject Stripe.Charge {..} =
       paymentMethod = payment_method,
       receiptEmail = receipt_email,
       receiptUrl = receipt_url,
+      ..
+    }
+
+mkCardDetails :: Stripe.ChargeCardDetails -> Events.CardDetails
+mkCardDetails Stripe.ChargeCardDetails {..} =
+  Events.CardDetails
+    { expMonth = exp_month,
+      expYear = exp_year,
       ..
     }
 

--- a/lib/mobility-core/src/Kernel/External/Payment/Stripe/Types/Webhook.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Stripe/Types/Webhook.hs
@@ -417,6 +417,25 @@ data MandateOptions = MandateOptions
   deriving stock (Show, Generic)
   deriving anyclass (FromJSON, ToJSON, ToSchema)
 
+--- Card Payment Method Details (embedded in Charge) ---
+data PaymentMethodDetails = PaymentMethodDetails
+  { card :: Maybe ChargeCardDetails
+  }
+  deriving stock (Show, Generic)
+  deriving anyclass (FromJSON, ToJSON, ToSchema)
+
+data ChargeCardDetails = ChargeCardDetails
+  { brand :: Text,
+    country :: Maybe Text,
+    exp_month :: Int,
+    exp_year :: Int,
+    fingerprint :: Maybe Text,
+    funding :: Maybe Text,
+    last4 :: Text
+  }
+  deriving stock (Show, Generic)
+  deriving anyclass (FromJSON, ToJSON, ToSchema)
+
 --- PaymentIntent Object ---
 data PaymentIntent = PaymentIntent
   { id :: Text,
@@ -505,6 +524,7 @@ data Charge = Charge
     paid :: Bool,
     payment_intent :: Maybe Text,
     payment_method :: Maybe PaymentMethodId,
+    payment_method_details :: Maybe PaymentMethodDetails,
     receipt_email :: Maybe Text,
     receipt_url :: Maybe Text,
     refunded :: Bool,


### PR DESCRIPTION
## Summary

- Add `PaymentMethodDetails` and `ChargeCardDetails` types to `Stripe/Types/Webhook.hs` to parse `payment_method_details.card` from Stripe charge webhook events
- Add `CardDetails` type to `Interface/Events/Types.hs` and `cardDetails` field to the interface `Charge` type
- Update `mkChargeObject` in `Interface/Stripe.hs` to map Stripe card data to the interface `CardDetails`

## Problem

Stripe sends card details (`brand`, `last4`, `exp_month`, `exp_year`, `country`, `fingerprint`, `funding`) inside `payment_method_details.card` in all `charge.*` webhook events. The `Stripe.Charge` type was missing this field, so it was silently dropped during JSON parsing and never reached the domain layer — leaving all card columns in `PaymentTransaction` as `Nothing`.

## Test plan

- [ ] Deploy and send a test Stripe `charge.succeeded` webhook with a card payment
- [ ] Verify the `Events.Charge` received by the handler has non-null `cardDetails`
- [ ] See companion PR in `nammayatri/nammayatri` where `mkChargeOrderTxn` consumes `cardDetails`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment charge events now include detailed card information (card brand, issuing country, expiry month/year, fingerprint, funding type, and masked card number).
  * Enhanced webhook processing to automatically extract and include card metadata in charge payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->