### PR TITLE
fix: stripe reverse transfer

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Payment/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface.hs
@@ -678,6 +678,7 @@ refundPayment serviceConfig mRoutingId req = case serviceConfig of
       RefundPaymentResp
         { refundId = req.refundsId,
           status = maybe REFUND_PENDING (.status) firstRefund,
+          amount = Nothing, -- Juspay refund responses do not surface the refunded amount
           errorCode = firstRefund >>= (.errorCode),
           errorMessage = firstRefund >>= (.errorMessage)
         }
@@ -700,6 +701,7 @@ refundPayment serviceConfig mRoutingId req = case serviceConfig of
       RefundPaymentResp
         { refundId = resp.id.getRefundId,
           status = resp.status,
+          amount = Just resp.amount,
           errorCode = resp.errorCode,
           errorMessage = Nothing
         }
@@ -724,6 +726,7 @@ getRefundStatus serviceConfig req = case serviceConfig of
       RefundPaymentResp
         { refundId = resp.id.getRefundId,
           status = resp.status,
+          amount = Just resp.amount,
           errorCode = resp.errorCode,
           errorMessage = Nothing
         }

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Stripe.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Stripe.hs
@@ -731,9 +731,11 @@ createRefund config req = do
     -- Driver receives payment directly (Direct Charges)
     ConnectedAccount -> createConnectedAccountRefund url apiKey
   where
-    -- Platform Charge: Need to reverse transfer
+    -- Platform Charge: never reverse the transfer. When the driver bears a refund, the
+    -- caller settles it against the driver's future payout via its own ledger; a Stripe
+    -- reverse_transfer on top would claw the same money back twice.
     createPlatformRefund url apiKey = do
-      let reverseTransfer = Just True
+      let reverseTransfer = Just False
           refundReq = mkRefundReq req reverseTransfer
       mkRefundResp <$> Stripe.createRefund url apiKey Nothing refundReq
 
@@ -755,8 +757,7 @@ createRefund config req = do
 
     mkRefundResp :: Stripe.RefundObject -> CreateRefundResp
     mkRefundResp Stripe.RefundObject {..} =
-      let reverseTransferId = transfer_reversal
-       in CreateRefundResp {status = castRefundStatus status, errorCode = failure_reason, ..}
+      CreateRefundResp {status = castRefundStatus status, amount = centsToUsd amount, errorCode = failure_reason, ..}
 
 castRefundStatus :: Stripe.RefundStatus -> RefundStatus
 castRefundStatus = \case
@@ -809,6 +810,5 @@ mkGetRefundResp Stripe.RefundObject {..} =
       amount = centsToUsd amount,
       currency = readMaybe . T.unpack $ T.toUpper currency,
       status = castRefundStatus status,
-      reverseTransferId = transfer_reversal,
       errorCode = failure_reason
     }

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
@@ -946,7 +946,7 @@ data CreateRefundReq = CreateRefundReq
 data CreateRefundResp = CreateRefundResp
   { id :: RefundId,
     status :: RefundStatus,
-    reverseTransferId :: Maybe Text,
+    amount :: HighPrecMoney,
     errorCode :: Maybe Text
   }
 
@@ -964,7 +964,6 @@ data GetRefundResp = GetRefundResp
     amount :: HighPrecMoney,
     currency :: Maybe Currency,
     status :: RefundStatus,
-    reverseTransferId :: Maybe Text,
     errorCode :: Maybe Text
   }
   deriving stock (Show)
@@ -1044,6 +1043,7 @@ data RefundPaymentReq = RefundPaymentReq
 data RefundPaymentResp = RefundPaymentResp
   { refundId :: Text,
     status :: RefundStatus,
+    amount :: Maybe HighPrecMoney,
     errorCode :: Maybe Text,
     errorMessage :: Maybe Text
   }


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refunds**
  * Refund responses now surface the refunded **amount** when provided by the payment provider (including refund status lookups); Juspay may omit this amount.
  * Updated Stripe platform refund behavior to adjust transfer reversal handling (connected-account flow unchanged).
  * Refund payloads were updated: removed `reverseTransferId` and added an explicit `amount` field for create/get refund responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->