### PR TITLE
fix: stripe connect taxId, vatId

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Stripe.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Stripe.hs
@@ -120,6 +120,7 @@ createConnectAccount config req = do
                   Stripe.CompanyDetails
                     { name = cd.name,
                       tax_id = cd.taxId,
+                      vat_id = cd.vatId,
                       address = cd.address
                     }
               else Nothing

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
@@ -764,7 +764,8 @@ data RefundsData = RefundsData
 
 data CompanyConnectDetails = CompanyConnectDetails
   { name :: Text,
-    taxId :: Maybe Text,
+    taxId :: Maybe Text, -- business registration number (e.g. Finnish Y-tunnus); Stripe company[tax_id]
+    vatId :: Maybe Text, -- VAT number (e.g. FI########); Stripe company[vat_id]
     address :: Maybe Address
   }
   deriving stock (Show, Eq, Generic)

--- a/lib/mobility-core/src/Kernel/External/Payment/Stripe/Types/Accounts.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Stripe/Types/Accounts.hs
@@ -267,6 +267,7 @@ data IndividualDetails = IndividualDetails
 data CompanyDetails = CompanyDetails
   { name :: Text,
     tax_id :: Maybe Text,
+    vat_id :: Maybe Text,
     address :: Maybe Address
   }
   deriving stock (Show, Eq, Generic, Read)
@@ -352,7 +353,9 @@ companyToForm :: CompanyDetails -> [(Text, Text)]
 companyToForm CompanyDetails {..} =
   [("company[name]", toQueryParam name)]
     ++ catMaybes
-      [("company[tax_id]",) <$> toQueryParam <$> tax_id]
+      [ ("company[tax_id]",) <$> toQueryParam <$> tax_id,
+        ("company[vat_id]",) <$> toQueryParam <$> vat_id
+      ]
     ++ maybe [] companyAddressToForm address
 
 companyAddressToForm :: Address -> [(Text, Text)]


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional VAT ID field for company payment account configuration to support enhanced company detail requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->