### PR TITLE
backend/fix:- Returing empty response in case of kapture when config …

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Ticket/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/Ticket/Interface.hs
@@ -30,8 +30,6 @@ import qualified Kernel.External.Ticket.Kapture.Types as KT
 import Kernel.Prelude
 import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
 import Kernel.Types.Common
-import Kernel.Types.Error (GenericError (InternalError))
-import Kernel.Utils.Error.Throwing (throwError)
 import Kernel.Utils.Servant.Client
 
 createTicket ::
@@ -71,7 +69,7 @@ addAndUpdateKaptureCustomer ::
   m KT.KaptureCustomerResp
 addAndUpdateKaptureCustomer serviceConfig req = case serviceConfig of
   KaptureConfig cfg -> Kapture.addAndUpdateKaptureCustomer cfg req
-  ZendeskConfig _ -> throwError $ InternalError "addAndUpdateKaptureCustomer not supported for Zendesk"
+  ZendeskConfig _ -> pure KT.KaptureCustomerResp {message = "Not applicable for Zendesk", status = "ok", kaptureCustomerId = ""}
 
 kaptureEncryption ::
   ( EncFlow m r,
@@ -84,7 +82,7 @@ kaptureEncryption ::
   m KT.KaptureEncryptionResp
 kaptureEncryption serviceConfig req = case serviceConfig of
   KaptureConfig cfg -> Kapture.kaptureEncryption cfg req
-  ZendeskConfig _ -> throwError $ InternalError "kaptureEncryption not supported for Zendesk"
+  ZendeskConfig _ -> pure KT.KaptureEncryptionResp {success = True, encrytedCc = "", encryptedIv = ""}
 
 kapturePullTicket ::
   ( EncFlow m r,
@@ -97,7 +95,7 @@ kapturePullTicket ::
   m KT.KapturePullTicketResp
 kapturePullTicket serviceConfig req = case serviceConfig of
   KaptureConfig cfg -> Kapture.kapturePullTicket cfg req
-  ZendeskConfig _ -> throwError $ InternalError "kapturePullTicket not supported for Zendesk"
+  ZendeskConfig _ -> pure KT.KapturePullTicketResp {totalCount = Just 0, message = [], status = "ok"}
 
 kaptureGetTicket ::
   ( EncFlow m r,
@@ -110,7 +108,7 @@ kaptureGetTicket ::
   m [KT.GetTicketResp]
 kaptureGetTicket serviceConfig req = case serviceConfig of
   KaptureConfig cfg -> Kapture.kaptureGetTicket cfg req
-  ZendeskConfig _ -> throwError $ InternalError "kaptureGetTicket not supported for Zendesk"
+  ZendeskConfig _ -> pure []
 
 getTicketStatus ::
   ( EncFlow m r,
@@ -123,4 +121,4 @@ getTicketStatus ::
   m [KT.GetTicketStatusResp]
 getTicketStatus serviceConfig req = case serviceConfig of
   KaptureConfig cfg -> Kapture.getTicketStatus cfg req
-  ZendeskConfig _ -> throwError $ InternalError "getTicketStatus not supported for Zendesk"
+  ZendeskConfig _ -> pure []


### PR DESCRIPTION
…is set to Zendesk

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Zendesk ticket operations to handle `ZendeskConfig` gracefully by returning successful “not applicable/empty” stub responses instead of throwing internal errors, ensuring downstream actions continue without interruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->