### PR TITLE
Map Zendesk unsupported ticket errors to 400 instead of 500

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Ticket/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/Ticket/Interface.hs
@@ -30,7 +30,7 @@ import qualified Kernel.External.Ticket.Kapture.Types as KT
 import Kernel.Prelude
 import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
 import Kernel.Types.Common
-import Kernel.Types.Error (GenericError (InternalError))
+import Kernel.Types.Error (GenericError (InternalError, InvalidRequest))
 import Kernel.Utils.Error.Throwing (throwError)
 import Kernel.Utils.Servant.Client
 
@@ -71,7 +71,7 @@ addAndUpdateKaptureCustomer ::
   m KT.KaptureCustomerResp
 addAndUpdateKaptureCustomer serviceConfig req = case serviceConfig of
   KaptureConfig cfg -> Kapture.addAndUpdateKaptureCustomer cfg req
-  ZendeskConfig _ -> throwError $ InternalError "addAndUpdateKaptureCustomer not supported for Zendesk"
+  ZendeskConfig _ -> throwError $ InvalidRequest "addAndUpdateKaptureCustomer not supported for Zendesk"
 
 kaptureEncryption ::
   ( EncFlow m r,
@@ -84,7 +84,7 @@ kaptureEncryption ::
   m KT.KaptureEncryptionResp
 kaptureEncryption serviceConfig req = case serviceConfig of
   KaptureConfig cfg -> Kapture.kaptureEncryption cfg req
-  ZendeskConfig _ -> throwError $ InternalError "kaptureEncryption not supported for Zendesk"
+  ZendeskConfig _ -> throwError $ InvalidRequest "kaptureEncryption not supported for Zendesk"
 
 kapturePullTicket ::
   ( EncFlow m r,
@@ -97,7 +97,7 @@ kapturePullTicket ::
   m KT.KapturePullTicketResp
 kapturePullTicket serviceConfig req = case serviceConfig of
   KaptureConfig cfg -> Kapture.kapturePullTicket cfg req
-  ZendeskConfig _ -> throwError $ InternalError "kapturePullTicket not supported for Zendesk"
+  ZendeskConfig _ -> throwError $ InvalidRequest "kapturePullTicket not supported for Zendesk"
 
 kaptureGetTicket ::
   ( EncFlow m r,
@@ -110,7 +110,7 @@ kaptureGetTicket ::
   m [KT.GetTicketResp]
 kaptureGetTicket serviceConfig req = case serviceConfig of
   KaptureConfig cfg -> Kapture.kaptureGetTicket cfg req
-  ZendeskConfig _ -> throwError $ InternalError "kaptureGetTicket not supported for Zendesk"
+  ZendeskConfig _ -> throwError $ InvalidRequest "kaptureGetTicket not supported for Zendesk"
 
 getTicketStatus ::
   ( EncFlow m r,
@@ -123,4 +123,4 @@ getTicketStatus ::
   m [KT.GetTicketStatusResp]
 getTicketStatus serviceConfig req = case serviceConfig of
   KaptureConfig cfg -> Kapture.getTicketStatus cfg req
-  ZendeskConfig _ -> throwError $ InternalError "getTicketStatus not supported for Zendesk"
+  ZendeskConfig _ -> throwError $ InvalidRequest "getTicketStatus not supported for Zendesk"


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (1f/12l)

### Root cause
The kapturePullTicket and related ticket interface functions in shared-kernel unconditionally throw InternalError when ZendeskConfig is active. InternalError maps to HTTP 500, which inflates ALB 5xx counts even though this is a configuration/client-side mismatch, not a server failure. Changing to InvalidRequest maps it to HTTP 400, removing it from 5xx alerting.

### Evidence
_see RCA_

### Rollback
Revert the commit or change InvalidRequest back to InternalError in lib/mobility-core/src/Kernel/External/Ticket/Interface.hs

---
_Draft PR — review and merge manually. Generated by Argus._