### PR TITLE
added udf1 field in create order request

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Payment/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface.hs
@@ -571,7 +571,8 @@ createPayment serviceConfig mRoutingId req = case serviceConfig of
               basket = req.basket,
               paymentRules = req.paymentRules,
               autoRefundPostSuccess = req.autoRefundPostSuccess,
-              paymentFilter = req.paymentFilter
+              paymentFilter = req.paymentFilter,
+              udf1 = req.udf1
             }
     resp <- Juspay.createOrder cfg mRoutingId juspayReq
     let clientSecret' = maybe "" (\p -> p.payload.clientAuthToken) (Just resp.sdk_payload)
@@ -630,7 +631,8 @@ createPayment serviceConfig mRoutingId req = case serviceConfig of
               basket = req.basket,
               paymentRules = req.paymentRules,
               autoRefundPostSuccess = req.autoRefundPostSuccess,
-              paymentFilter = req.paymentFilter
+              paymentFilter = req.paymentFilter,
+              udf1 = req.udf1
             }
     resp <- PaytmEDC.createOrder cfg mRoutingId paytmReq
     let clientSecret' = maybe "" (\p -> p.payload.clientAuthToken) (Just resp.sdk_payload)

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
@@ -324,7 +324,8 @@ mkCreateOrderReq returnUrl autoRefundConflictThresholdMinutes cfgWebhookUrl clie
           auto_refund_conflict_threshold_minutes = autoRefundConflictThresholdMinutes,
           auto_refund_post_success = bool "false" "true" <$> autoRefundPostSuccess,
           payment_rules = mkPaymentRules <$> paymentRules,
-          payment_filter = mkPaymentFilter <$> paymentFilter
+          payment_filter = mkPaymentFilter <$> paymentFilter,
+          udf1 = udf1
         }
 
 mkPaymentFilter :: PaymentFilter -> Juspay.PaymentFilter

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
@@ -93,7 +93,8 @@ data CreateOrderReq = CreateOrderReq
     basket :: Maybe [Basket],
     paymentRules :: Maybe PaymentRules,
     autoRefundPostSuccess :: Maybe Bool,
-    paymentFilter :: Maybe PaymentFilter
+    paymentFilter :: Maybe PaymentFilter,
+    udf1 :: Maybe Text
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON, ToSchema)
@@ -1006,7 +1007,8 @@ data CreatePaymentReq = CreatePaymentReq
     basket :: Maybe [Basket],
     paymentRules :: Maybe PaymentRules,
     autoRefundPostSuccess :: Maybe Bool,
-    paymentFilter :: Maybe PaymentFilter
+    paymentFilter :: Maybe PaymentFilter,
+    udf1 :: Maybe Text
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON, ToSchema)

--- a/lib/mobility-core/src/Kernel/External/Payment/Juspay/Types/CreateOrder.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Juspay/Types/CreateOrder.hs
@@ -55,7 +55,8 @@ data CreateOrderReq = CreateOrderReq
     basket :: Maybe Text,
     auto_refund_conflict_threshold_minutes :: Maybe Int,
     payment_rules :: Maybe PaymentRules,
-    payment_filter :: Maybe PaymentFilter
+    payment_filter :: Maybe PaymentFilter,
+    udf1 :: Maybe Text
   }
   deriving stock (Show, Eq, Generic)
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced payment processing to support an additional optional custom field (`udf1`) in payment order creation requests, improving flexibility for downstream payment integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->