### PR TITLE
feat: add LTS Redis primary-secondary fallback for list and maybe-list…

### DIFF
--- a/lib/mobility-core/src/Kernel/Storage/Hedis/Queries.hs
+++ b/lib/mobility-core/src/Kernel/Storage/Hedis/Queries.hs
@@ -295,6 +295,52 @@ runInMasterLTSRedisCell f = do
       logInfo "LTS_REDIS_ROUTING: Using primary LTS Redis (current deployment Redis)"
       f
 
+-- Read operation for LTS list queries: tries primary LTS first, falls back to secondary LTS if empty.
+-- Analogous to runInMultiCloudRedisForList but for ltsHedisEnv/secondaryLTSHedisEnv.
+runInMultiCloudLTSRedisForList ::
+  (HedisLTSFlow m env, TryException m) =>
+  m [a] ->
+  m [a]
+runInMultiCloudLTSRedisForList action = do
+  ltsEnv <- asks (.ltsHedisEnv)
+  mbSecondaryEnv <- asks (.secondaryLTSHedisEnv)
+  primaryResult <- local (\env -> env{hedisEnv = ltsEnv, hedisClusterEnv = ltsEnv}) action
+  case (primaryResult, mbSecondaryEnv) of
+    ([], Just secondaryEnv) -> do
+      logInfo "MULTI_CLOUD_LTS: Primary returned empty, trying secondary"
+      secondaryResult <-
+        withTryCatch "runInMultiCloudLTSRedisForList" $
+          local (\env -> env{hedisEnv = secondaryEnv, hedisClusterEnv = secondaryEnv}) action
+      case secondaryResult of
+        Left err -> do
+          logError $ "MULTI_CLOUD_LTS: Secondary read failed " <> show err
+          pure []
+        Right result -> pure result
+    _ -> pure primaryResult
+
+-- Read operation for LTS hmGet queries: tries primary LTS first, falls back to secondary LTS if all Nothing.
+-- hmGet always returns a same-length [Maybe a], so [] fallback doesn't apply — use all-Nothing check instead.
+runInMultiCloudLTSRedisForMaybeList ::
+  (HedisLTSFlow m env, TryException m) =>
+  m [Maybe a] ->
+  m [Maybe a]
+runInMultiCloudLTSRedisForMaybeList action = do
+  ltsEnv <- asks (.ltsHedisEnv)
+  mbSecondaryEnv <- asks (.secondaryLTSHedisEnv)
+  primaryResult <- local (\env -> env{hedisEnv = ltsEnv, hedisClusterEnv = ltsEnv}) action
+  case (not (null primaryResult) && Kernel.Prelude.all isNothing primaryResult, mbSecondaryEnv) of
+    (True, Just secondaryEnv) -> do
+      logInfo "MULTI_CLOUD_LTS: Primary returned all Nothing, trying secondary"
+      secondaryResult <-
+        withTryCatch "runInMultiCloudLTSRedisForMaybeList" $
+          local (\env -> env{hedisEnv = secondaryEnv, hedisClusterEnv = secondaryEnv}) action
+      case secondaryResult of
+        Left err -> do
+          logError $ "MULTI_CLOUD_LTS: Secondary read failed " <> show err
+          pure primaryResult
+        Right result -> pure result
+    _ -> pure primaryResult
+
 withLTSRedis ::
   (HedisFlow m env, TryException m, HasField "ltsHedisEnv" env HedisEnv) => m f -> m f
 withLTSRedis f =


### PR DESCRIPTION
… reads

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved resilience for multi-cloud Redis operations with automatic retry behavior. The system now checks primary results and conditionally falls back to a secondary cloud environment (e.g., empty list results or “all missing” values), improving reliability in distributed deployments.

* **Bug Fixes**
  * Enhanced handling of partial/empty Redis responses to ensure consistent outcomes even when the primary environment fails or returns no usable data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->