### PR TITLE
KV/Enh: Per-table recache-on-find flag (tablesForRecacheFind)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -387,11 +387,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781524630,
-        "narHash": "sha256-NhhQMQF4RrAzU1w5oUbRbH+Ke4q1lxxHmqsUFz2AtWE=",
+        "lastModified": 1782900600,
+        "narHash": "sha256-INsHO5MQ/B92GSh5Z2YocvGJ853RZy8h73LBJ7dyqwo=",
         "owner": "nammayatri",
         "repo": "euler-hs",
-        "rev": "0cde21fc9be69268839a84e9c99935f53f0e364a",
+        "rev": "3e0c960a608a96451c992a3a10af9faf861fb406",
         "type": "github"
       },
       "original": {

--- a/lib/mobility-core/src/Kernel/Beam/Functions.hs
+++ b/lib/mobility-core/src/Kernel/Beam/Functions.hs
@@ -117,7 +117,8 @@ meshConfig =
       cerealEnabled = False,
       tableShardModRange = (0, 128),
       redisKeyPrefix = "",
-      forceDrainToDB = False
+      forceDrainToDB = False,
+      recacheFindEnabled = False
     }
 
 runInReplica :: (L.MonadFlow m, Log m) => m a -> m a
@@ -185,6 +186,7 @@ setMeshConfigWithTables modelName mSchema meshConfig' tables' = do
                     secondaryEnabled =
                       fromMaybe False tables'.enableSecondaryCloudRead
                         && modelName `elem` fromMaybe [] tables'.tablesForSecondaryCloudRead
+                    recacheEnabled = modelName `elem` fromMaybe [] tables'.tablesForRecacheFind
                  in meshConfig'
                       { meshEnabled = True,
                         kvHardKilled = False,
@@ -192,7 +194,8 @@ setMeshConfigWithTables modelName mSchema meshConfig' tables' = do
                         redisTtl = redisTtl',
                         tableShardModRange = tableShardModRange',
                         redisKeyPrefix = redisKeyPrefix',
-                        secondaryRedisEnabled = secondaryEnabled || tables'.enableAllTablesForSecondaryCloudRead == Just True
+                        secondaryRedisEnabled = secondaryEnabled || tables'.enableAllTablesForSecondaryCloudRead == Just True,
+                        recacheFindEnabled = recacheEnabled
                       }
 
 getTablesOption :: (L.MonadFlow m, HasCallStack) => m Tables

--- a/lib/mobility-core/src/Kernel/Types/Common.hs
+++ b/lib/mobility-core/src/Kernel/Types/Common.hs
@@ -80,6 +80,7 @@ data Tables = Tables
     enableSecondaryCloudRead :: Maybe Bool,
     tablesForSecondaryCloudRead :: Maybe [Text],
     enableAllTablesForSecondaryCloudRead :: Maybe Bool,
+    tablesForRecacheFind :: Maybe [Text],
     drainerTtlConfigs :: Maybe (HM.HashMap Text Integer),
     enableFindAllForMultiCloud :: Maybe Bool
   }
@@ -100,6 +101,7 @@ defaultTableData =
       enableSecondaryCloudRead = Nothing,
       tablesForSecondaryCloudRead = Nothing,
       enableAllTablesForSecondaryCloudRead = Nothing,
+      tablesForRecacheFind = Nothing,
       drainerTtlConfigs = Nothing,
       enableFindAllForMultiCloud = Nothing
     }


### PR DESCRIPTION
## What

Wires shared-kernel to euler-hs [PR #66](https://github.com/nammayatri/euler-hs/pull/66), which adds `MeshConfig.recacheFindEnabled` — a per-table opt-in for recaching a DB row back into pod-local Redis on a KV miss in the single-row find path (`findWithKVConnector`).

## Changes

- **`Kernel/Beam/Functions.hs`**
  - Default `meshConfig` sets `recacheFindEnabled = False` (compiles against new euler-hs `MeshConfig`).
  - `setMeshConfigWithTables` sets `recacheFindEnabled = True` when the model is listed in `tablesForRecacheFind`.
- **`Kernel/Types/Common.hs`**
  - Adds `Tables.tablesForRecacheFind :: Maybe [Text]` (populated from `kv_configs`), default `Nothing`.
- **`flake.nix` / `flake.lock`**
  - Pins euler-hs to `kv/enh/per-table-recache-find-flag` (rev `60e8a0f`).

## Behaviour

A table opts into recache-on-find purely by being listed in `tablesForRecacheFind`. Defaults to off everywhere → behavior is byte-identical to today until a table opts in.

## Notes

- Depends on euler-hs PR #66 being merged (or the pinned branch remaining available).
- `findOne` path only; `findAll` / update paths unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selectively enabling refreshed lookup behavior for specific data sets.

* **Bug Fixes**
  * Improved default configuration handling so the new lookup behavior stays disabled unless explicitly configured.
  * Updated mesh configuration logic to respect the new table-level setting consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->