### PR TITLE
backend/enh/added-flag-for-runInMasterCloudApi

### DIFF
--- a/lib/mobility-core/src/Kernel/External/MasterCloudForward.hs
+++ b/lib/mobility-core/src/Kernel/External/MasterCloudForward.hs
@@ -134,8 +134,9 @@ getRunApiInMasterCloud = do
   envVal <- lookupEnv "RUN_API_IN_MASTER_CLOUD"
   pure (fromMaybe False (readMaybe =<< envVal))
 
--- Drop-in replacement for @callAPI@. Triple-gated: env on + masterUrl set +
--- masterSecret set → forwarded. Anything else → direct call.
+-- Drop-in replacement for @callAPI@. Quad-gated: caller flag on +
+-- masterUrl set + masterSecret set → forwarded. Anything else → direct call.
+-- flag is for city specific forwarder.
 runThroughMasterCloud ::
   ( HasMasterCloudForwarder r,
     MonadReader r m,
@@ -147,9 +148,9 @@ runThroughMasterCloud ::
   BaseUrl ->
   ET.EulerClient a ->
   Text ->
+  Bool ->
   m (Either ClientError a)
-runThroughMasterCloud origBaseUrl eClient desc = do
-  shouldForward <- liftIO getRunApiInMasterCloud
+runThroughMasterCloud origBaseUrl eClient desc shouldForward = do
   cfg <- asks masterCloudProxyConfig
   case (shouldForward, cfg.masterUrl, cfg.masterSecret) of
     (True, Just fwdUrl, Just secret) -> do

--- a/lib/mobility-core/test-integration/Main.hs
+++ b/lib/mobility-core/test-integration/Main.hs
@@ -193,7 +193,7 @@ main = do
         setEnv "RUN_API_IN_MASTER_CLOUD" "True"
         rForwarded <-
           KFlow.runFlowR flowRt env $
-            runThroughMasterCloud todoBaseUrl (getTodoClient 1) "getTodo-forwarded"
+            runThroughMasterCloud todoBaseUrl (getTodoClient 1) "getTodo-forwarded" True
 
         -- Compare.
         case (rDirect, rForwarded) of


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted request routing so forwarding happens only when the caller explicitly enables it and the required master configuration (URL and secret) is present.
  * Preserved the existing direct-request behavior when forwarding is disabled or not properly configured.
* **Tests**
  * Updated integration coverage to pass the new explicit routing flag when exercising the forwarded request path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->