### PR TITLE
Backend/fix/Changed-SMS-Provider-Logic,Added-VM-Metrics

### DIFF
--- a/lib/mobility-core/src/Kernel/External/SMS/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/SMS/Interface.hs
@@ -15,10 +15,7 @@ module Kernel.External.SMS.Interface
   )
 where
 
-import Data.Char (digitToInt)
-import Data.List (length, (!!))
-import qualified Data.Text as T
-import EulerHS.Prelude hiding (length)
+import EulerHS.Prelude
 import Kernel.External.SMS.DigoEngage.Config as Reexport
 import Kernel.External.SMS.ExotelSms.Config as Reexport
 import Kernel.External.SMS.GupShup.Config as Reexport
@@ -38,7 +35,7 @@ import Kernel.External.SMS.MyValueFirst.Config as Reexport
 import Kernel.External.SMS.PinbixSms.Config as Reexport
 import Kernel.External.SMS.Types as Reexport
 import Kernel.External.SMS.VonageSms.Config as Reexport
-import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
+import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics, incrementSmsProviderResponseCounter)
 import Kernel.Types.Common
 import Kernel.Types.Error
 import Kernel.Utils.Common
@@ -83,31 +80,18 @@ sendSMS SmsHandler {..} req = do
   when (null providers) $
     throwError $
       InternalError "No sms serive provider configured"
-  let totalCount = length providers
-      phoneNum = req.phoneNumber
-      lastDigit =
-        if T.null phoneNum
-          then 0
-          else digitToInt (T.last phoneNum)
-
-      startIndex = lastDigit `mod` totalCount
-  circularAttempt providers totalCount startIndex 0
+  attemptProviders providers
   where
-    circularAttempt providers totalCount startIndex currentAttempts = do
-      when (currentAttempts >= totalCount) $
-        throwError $
-          InternalError "Not able to send sms with all the configured providers"
-
-      let currentIndex = (startIndex + currentAttempts) `mod` totalCount
-          preferredProvider = providers !! currentIndex
-      smsConfig <- getProviderConfig preferredProvider
+    attemptProviders [] =
+      throwError $
+        InternalError "Not able to send sms with all the configured providers"
+    attemptProviders (provider : rest) = do
+      smsConfig <- getProviderConfig provider
       result <- withTryCatch "sendSMS" $ sendSMS' smsConfig req
-
+      let providerName = show provider
       case result of
-        Left _ -> fallback
+        Left _ -> incrementSmsProviderResponseCounter providerName "failure" >> attemptProviders rest
         Right res -> case res of
-          UnknownError -> fallback
-          Fail -> fallback
-          _ -> pure res
-      where
-        fallback = circularAttempt providers totalCount startIndex (currentAttempts + 1)
+          UnknownError -> incrementSmsProviderResponseCounter providerName "failure" >> attemptProviders rest
+          Fail -> incrementSmsProviderResponseCounter providerName "failure" >> attemptProviders rest
+          _ -> incrementSmsProviderResponseCounter providerName "success" >> pure res

--- a/lib/mobility-core/src/Kernel/Mock/App.hs
+++ b/lib/mobility-core/src/Kernel/Mock/App.hs
@@ -79,6 +79,7 @@ instance CoreMetrics (MockM e) where
   addOpenTripPlannerResponse _ _ _ = return ()
   addOpenTripPlannerLatency _ _ _ = return ()
   incrementTryExceptionCounter _ _ = return ()
+  incrementSmsProviderResponseCounter _ _ = return ()
 
 instance MonadTime (MockM e) where
   getCurrentTime = liftIO getCurrentTime

--- a/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics.hs
+++ b/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics.hs
@@ -505,6 +505,23 @@ addOpenTripPlannerLatencyImplementation queryType status latency = do
       (queryType, status, version.getDeploymentVersion)
       (`P.observe` ((/ 1000) . fromIntegral $ getMilliseconds latency))
 
+incrementSmsProviderResponseCounterImplementation ::
+  ( HasCoreMetrics r,
+    L.MonadFlow m,
+    MonadReader r m
+  ) =>
+  Text ->
+  Text ->
+  m ()
+incrementSmsProviderResponseCounterImplementation provider status = do
+  cmContainer <- asks (.coreMetrics)
+  version <- asks (.version)
+  L.runIO $
+    P.withLabel
+      cmContainer.smsProviderResponseCounter
+      (provider, status, version.getDeploymentVersion)
+      P.incCounter
+
 incrementTryExceptionCounterImplementation ::
   ( HasCoreMetrics r,
     L.MonadFlow m,

--- a/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics/Types.hs
+++ b/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics/Types.hs
@@ -76,6 +76,9 @@ type OpenTripPlannerResponseMetric = P.Vector P.Label4 P.Counter
 
 type OpenTripPlannerLatencyMetric = P.Vector P.Label3 P.Histogram
 
+-- | Per-provider SMS outcome counter (labels: "provider", "status", "version").
+type SmsProviderResponseMetric = P.Vector P.Label3 P.Counter
+
 newBuckets :: [Double]
 newBuckets = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 20, 25, 30, 40, 50]
 
@@ -114,6 +117,7 @@ class CoreMetrics m where
   incrementRedisStreamDead :: Int -> m ()
   setRedisStreamLength :: Int -> Integer -> m ()
   setRedisStreamPending :: Int -> Integer -> m ()
+  incrementSmsProviderResponseCounter :: Text -> Text -> m ()
 
 data CoreMetricsContainer = CoreMetricsContainer
   { requestLatency :: RequestLatencyMetric,
@@ -142,7 +146,8 @@ data CoreMetricsContainer = CoreMetricsContainer
     kvRedisMetricsContainer :: KVMetrics.KVMetricHandler,
     genericLatencyMetrics :: GenericLatencyMetric,
     openTripPlannerResponseMetric :: OpenTripPlannerResponseMetric,
-    openTripPlannerLatencyMetric :: OpenTripPlannerLatencyMetric
+    openTripPlannerLatencyMetric :: OpenTripPlannerLatencyMetric,
+    smsProviderResponseCounter :: SmsProviderResponseMetric
   }
 
 registerCoreMetricsContainer :: IO CoreMetricsContainer
@@ -174,6 +179,7 @@ registerCoreMetricsContainer = do
   genericLatencyMetrics <- registerLatencyMetrics
   openTripPlannerResponseMetric <- registerOpenTripPlannerResponseMetric
   openTripPlannerLatencyMetric <- registerOpenTripPlannerLatencyMetric
+  smsProviderResponseCounter <- registerSmsProviderResponseMetric
   return CoreMetricsContainer {..}
 
 registerDatastoresLatencyMetrics :: IO DatastoresLatencyMetric
@@ -381,3 +387,11 @@ registerOpenTripPlannerLatencyMetric =
       P.histogram info newBuckets
   where
     info = P.Info "open_trip_planner_latency_seconds" "OpenTripPlanner request latency in seconds"
+
+registerSmsProviderResponseMetric :: IO SmsProviderResponseMetric
+registerSmsProviderResponseMetric =
+  P.register $
+    P.vector ("provider", "status", "version") $
+      P.counter info
+  where
+    info = P.Info "sms_provider_response_counter" "SMS provider outcome counter labelled by provider, status (success/failure) and version"

--- a/lib/mobility-core/src/Kernel/Types/Flow.hs
+++ b/lib/mobility-core/src/Kernel/Types/Flow.hs
@@ -243,6 +243,7 @@ instance Metrics.HasCoreMetrics r => Metrics.CoreMetrics (FlowR r) where
   addOpenTripPlannerResponse = Metrics.addOpenTripPlannerResponseImplementation
   addOpenTripPlannerLatency = Metrics.addOpenTripPlannerLatencyImplementation
   incrementTryExceptionCounter = Metrics.incrementTryExceptionCounterImplementation
+  incrementSmsProviderResponseCounter = Metrics.incrementSmsProviderResponseCounterImplementation
 
 instance MonadMonitor (FlowR r) where
   doIO = liftIO

--- a/lib/mobility-core/test/src/APIExceptions.hs
+++ b/lib/mobility-core/test/src/APIExceptions.hs
@@ -79,6 +79,7 @@ instance Metrics.CoreMetrics IO where
   addOpenTripPlannerLatency _ _ _ = return ()
   incrementTryExceptionCounter _ _ = return ()
   incrementProducerError _ = return ()
+  incrementSmsProviderResponseCounter _ _ = return ()
 
 httpExceptionTests :: TestTree
 httpExceptionTests =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SMS delivery now records per-provider outcome metrics (provider, status, and deployment version) for improved monitoring.

* **Bug Fixes**
  * SMS sending now iterates through the configured providers in order, continuing after failures.
  * If all configured providers fail, the system now returns a clear error message instead of failing silently.

* **Tests / Chores**
  * Updated metric stubs and wiring in mocks/tests to support the new SMS outcome metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->