### PR TITLE
feat: add partial (pinned) KV secondary index support

### DIFF
--- a/lib/mobility-core/mobility-core.cabal
+++ b/lib/mobility-core/mobility-core.cabal
@@ -958,6 +958,7 @@ test-suite mobility-core-tests
       Centesimal
       ComputeIntersectionTests
       DistanceCalculation
+      PartialIndexTests
       Predicates
       SettlementEmail
       SettlementMimeCsv

--- a/lib/mobility-core/src/Kernel/Beam/Lib/UtilsTH.hs
+++ b/lib/mobility-core/src/Kernel/Beam/Lib/UtilsTH.hs
@@ -3,6 +3,8 @@
 
 module Kernel.Beam.Lib.UtilsTH
   ( enableKVPG,
+    enableKVPGWithPartialIndex,
+    SKeyPartial (..),
     HasSchemaName (..),
     mkTableInstances,
     mkTableInstancesWithTModifier,
@@ -56,10 +58,33 @@ emptyTextHashMap = HMI.empty
 emptyValueHashMap :: M.Map Text (A.Value -> A.Value)
 emptyValueHashMap = M.empty
 
+-- | A partial secondary index. The key is written only for rows where the pinned fields equal the
+--   given values (like Postgres @CREATE INDEX ... WHERE col = 'value'@). The pinned fields double as
+--   the key columns, so nothing in the KV layer needs to change - a row just carries the key when it
+--   matches.
+--
+--   e.g. @SKeyPartial [('status, "ACTIVE")]@ indexes status only for ACTIVE rows (one set, status_ACTIVE).
+data SKeyPartial = SKeyPartial [(Name, String)]
+
+-- | Default for almost every table. Output is identical to before.
 enableKVPG :: Name -> [Name] -> [[Name]] -> Q [Dec]
-enableKVPG name pKeyN sKeysN = do
+enableKVPG name pKeyN sKeysN = kvpgDecs name pKeyN (map (\cols -> (cols, [])) sKeysN)
+
+-- | Like 'enableKVPG' but the table can also declare partial (pinned) secondary keys. Plain keys are
+--   the usual @[[Name]]@; partial keys go in the second list (pass @[]@ when there are none).
+--
+-- > enableKVPGWithPartialIndex ''SearchRequestT ['id]
+-- >   [['transactionId]]                    -- plain
+-- >   [SKeyPartial [('status, "ACTIVE")]]   -- partial: status indexed only when ACTIVE
+enableKVPGWithPartialIndex :: Name -> [Name] -> [[Name]] -> [SKeyPartial] -> Q [Dec]
+enableKVPGWithPartialIndex name pKeyN plainSKeys partialSKeys =
+  kvpgDecs name pKeyN (map (\cols -> (cols, [])) plainSKeys ++ map (\(SKeyPartial pins) -> (map fst pins, pins)) partialSKeys)
+
+-- | Shared by both entry points. A secondary key is @(cols, pins)@: empty pins = plain, non-empty = partial.
+kvpgDecs :: Name -> [Name] -> [([Name], [(Name, String)])] -> Q [Dec]
+kvpgDecs name pKeyN sKeySpecs = do
   [tModeMeshSig, tModeMeshDec] <- tableTModMeshD name
-  [kvConnectorDec] <- kvConnectorInstancesD name pKeyN sKeysN
+  [kvConnectorDec] <- kvConnectorInstancesD name pKeyN sKeySpecs
   [meshMetaDec] <- meshMetaInstancesDPG name
   sqlObjectToJSONInstance <- mkSQLObjectToJSONInstance name
   pure [tModeMeshSig, tModeMeshDec, meshMetaDec, kvConnectorDec, sqlObjectToJSONInstance] -- ++ cerealDec
@@ -81,12 +106,13 @@ tableTModMeshD name = do
 --   keyMap :: HM.HashMap Text Bool -- True implies it is primary key and False implies secondary
 --   primaryKey :: table -> PrimaryKey
 --   secondaryKeys:: table -> [SecondaryKey]
-kvConnectorInstancesD :: Name -> [Name] -> [[Name]] -> Q [Dec]
-kvConnectorInstancesD name pKeyN sKeysN = do
+-- sKeySpecs: one (cols, pins) per secondary key; empty pins = plain, non-empty = partial.
+kvConnectorInstancesD :: Name -> [Name] -> [([Name], [(Name, String)])] -> Q [Dec]
+kvConnectorInstancesD name pKeyN sKeySpecs = do
   let pKey = sortAndGetKey pKeyN
-      sKeys = filter (\k -> pKey /= sortAndGetKey k) sKeysN
+      sKeys = filter (\k -> pKey /= sortAndGetKey (fst k)) sKeySpecs
       pKeyPair = TupE [Just $ LitE $ StringL pKey, Just $ ConE 'True]
-      sKeyPairs = map (\k -> TupE [Just $ LitE $ StringL $ sortAndGetKey k, Just $ ConE 'False]) sKeys
+      sKeyPairs = map (\k -> TupE [Just $ LitE $ StringL $ sortAndGetKey (fst k), Just $ ConE 'False]) sKeys
   let tableNameD = FunD 'KV.tableName [Clause [] (NormalB (LitE (StringL $ init $ camel (nameBase name)))) []]
       keyMapD = FunD 'KV.keyMap [Clause [] (NormalB (AppE (VarE 'HM.fromList) (ListE (pKeyPair : sKeyPairs)))) []]
       primaryKeyD = FunD 'KV.primaryKey [Clause [] (NormalB getPrimaryKeyE) []]
@@ -97,18 +123,26 @@ kvConnectorInstancesD name pKeyN sKeysN = do
     getPrimaryKeyE =
       let obj = mkName "obj"
        in LamE [VarP obj] (AppE (ConE 'KV.PKey) (ListE (map (\n -> TupE [Just $ keyNameTextE n, Just $ getRecFieldE n obj]) pKeyN)))
-    getSecondaryKeysE =
-      if null sKeysN || sKeysN == [[]]
-        then LamE [WildP] (ListE [])
-        else do
-          let obj = mkName "obj"
-          LamE
-            [VarP obj]
-            ( ListE $
-                map
-                  (AppE (ConE 'KV.SKey) . ListE . map (\n -> TupE [Just $ keyNameTextE n, Just $ getRecFieldE n obj]))
-                  sKeysN
-            )
+    getSecondaryKeysE
+      | null sKeySpecs || all (null . fst) sKeySpecs = LamE [WildP] (ListE [])
+      -- All plain: emit the historical @[SKey ...]@ form unchanged (byte-identical output).
+      | all (null . snd) sKeySpecs =
+        let obj = mkName "obj"
+         in LamE [VarP obj] (ListE $ map (\spec -> skeyExprE obj (fst spec)) sKeySpecs)
+      -- At least one pinned key: @concat@ of per-key lists (a singleton, or [] when the pin fails).
+      | otherwise =
+        let obj = mkName "obj"
+         in LamE [VarP obj] (AppE (VarE 'concat) (ListE $ map (perSpecListE obj) sKeySpecs))
+    perSpecListE obj spec = case snd spec of
+      [] -> ListE [skeyExprE obj (fst spec)]
+      pins -> CondE (gateE obj pins) (ListE [skeyExprE obj (fst spec)]) (ListE [])
+    -- Conjunction of @utilTransform (field obj) == T.pack "constant"@ over all pinned fields.
+    gateE obj pins =
+      AppE (VarE 'and) $
+        ListE $
+          map (\(f, c) -> AppE (AppE (VarE '(==)) (getRecFieldE f obj)) (AppE (VarE 'T.pack) (LitE $ StringL c))) pins
+    skeyExprE obj cols =
+      AppE (ConE 'KV.SKey) (ListE $ map (\n -> TupE [Just $ keyNameTextE n, Just $ getRecFieldE n obj]) cols)
     getRecFieldE f obj =
       let fieldName = (splitColon $ nameBase f)
        in AppE (AppE (AppE (VarE 'utilTransform) (VarE 'emptyValueHashMap)) (LitE . StringL $ fieldName)) (AppE (VarE $ mkName fieldName) (VarE obj))

--- a/lib/mobility-core/test/app/Main.hs
+++ b/lib/mobility-core/test/app/Main.hs
@@ -19,6 +19,7 @@ import Centesimal
 import ComputeIntersectionTests
 import DistanceCalculation
 import EulerHS.Prelude
+import PartialIndexTests
 import Predicates
 import SettlementEmail
 import SignatureAuth
@@ -45,5 +46,6 @@ specs = return $ testGroup "Tests" [unitTests]
           readVersionTests,
           snippetsCheckTests,
           predicatesTests,
-          settlementEmailTests
+          settlementEmailTests,
+          partialIndexTests
         ]

--- a/lib/mobility-core/test/src/PartialIndexTests.hs
+++ b/lib/mobility-core/test/src/PartialIndexTests.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | Tests for partial (pinned) secondary keys via 'enableKVPGWithPartialIndex'.
+--
+--   The table has a normal secondary key on driverId and a partial one on status pinned to "ACTIVE".
+--   We check that secondaryKeys only emits the pinned key when status is ACTIVE - that is what the KV
+--   layer uses to decide index membership on create/find/update.
+module PartialIndexTests (partialIndexTests) where
+
+import qualified Data.HashMap.Strict as HM
+import qualified Database.Beam as B
+import EulerHS.KVConnector.Types (KVConnector (keyMap, secondaryKeys), SecondaryKey (..))
+import EulerHS.Prelude hiding (id)
+import Kernel.Beam.Lib.UtilsTH
+import Test.Tasty
+import Test.Tasty.HUnit
+
+data PartialTestT f = PartialTestT
+  { id :: B.C f Text,
+    driverId :: B.C f Text,
+    status :: B.C f Text
+  }
+  deriving (Generic, B.Beamable)
+
+instance B.Table PartialTestT where
+  data PrimaryKey PartialTestT f
+    = Id (B.C f Text)
+    deriving (Generic, B.Beamable)
+  primaryKey = Id . id
+
+type PartialTest = PartialTestT Identity
+
+$( enableKVPGWithPartialIndex
+     ''PartialTestT
+     ['id]
+     [['driverId]] -- plain secondary keys (same syntax as enableKVPG)
+     [SKeyPartial [('status, "ACTIVE")]] -- partial: status indexed only when ACTIVE
+ )
+
+row :: Text -> PartialTest
+row st = PartialTestT {id = "id-" <> st, driverId = "d1", status = st}
+
+-- | The raw (field, value) pairs of each secondary key the row currently carries.
+sKeys :: PartialTest -> [[(Text, Text)]]
+sKeys = map (\(SKey s) -> s) . secondaryKeys
+
+partialIndexTests :: TestTree
+partialIndexTests =
+  testGroup
+    "KV partial index (enableKVPGWithPartialIndex)"
+    [ testCase "ACTIVE row IS indexed under the pinned status key" $
+        sKeys (row "ACTIVE") @?= [[("driverId", "d1")], [("status", "ACTIVE")]],
+      testCase "non-ACTIVE row is NOT indexed under the pinned status key" $
+        sKeys (row "INACTIVE") @?= [[("driverId", "d1")]],
+      testCase "another non-ACTIVE value is also skipped" $
+        sKeys (row "COMPLETED") @?= [[("driverId", "d1")]],
+      testCase "keyMap registers id (pk) + driverId + status" $
+        sort (HM.keys (keyMap @PartialTest)) @?= sort ["id", "driverId", "status"]
+    ]


### PR DESCRIPTION
## What

Adds opt-in **partial (pinned) secondary index** support to the KV codegen. A table can declare a secondary key that is indexed only for rows whose field equals a fixed value — the KV analog of a Postgres partial index (`CREATE INDEX ... WHERE status = 'ACTIVE'`).

```haskell
$(enableKVPGWithPartialIndex ''SearchRequestT ['id]
    [['transactionId]]                    -- plain keys, unchanged
    [SKeyPartial [('status, "ACTIVE")]])  -- partial: status indexed only when ACTIVE
```

## Why

A bare index on a low-cardinality column like `status` explodes into one large Redis set per value (which is why such columns are deny-listed). Pinning the value bounds the index to a single small set `..._status_ACTIVE`, populated only by ACTIVE rows — safe to index when that subset is small.

## How it works

- `SKeyPartial [(field, "value")]` — the pinned fields are the key columns.
- Codegen emits `secondaryKeys` that includes the pinned key only when the row matches: `if status obj == "ACTIVE" then [SKey ...] else []`.
- Because the pinned field is part of the key, `create` / `find` / `update` / `delete` in euler-hs already do the right thing — **no runtime changes**. Index membership is driven entirely by the generated `secondaryKeys`.

## Compatibility

- `enableKVPG` keeps its exact signature, and the all-plain codegen path is **byte-identical** to before — every existing table is unaffected.
- `enableKVPGWithPartialIndex` is fully opt-in.

## Testing

- `PartialIndexTests` asserts the gate: ACTIVE row carries the pinned key, non-ACTIVE rows don't, and `keyMap` registers all keys.
- `mobility-core` library + test suite build green under `-Werror`; all tests pass.

## Notes

- The pin value is compared as text (the field's `toJSON` string), so pass the serialized enum value (e.g. `"ACTIVE"`) — the same representation used in the Redis key. A typo produces a permanently-empty index (no compile-time enum check).
- Declaring this from YAML specs (namma-dsl codegen) is a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for partially pinned secondary indexes, allowing some indexed fields to be included only when they match specific values.
  * Expanded test coverage for the new indexing behavior.

* **Bug Fixes**
  * Secondary index generation now handles empty, standard, and partially pinned index configurations more consistently.

* **Tests**
  * Added a new test suite covering index output for matching and non-matching field values.
  * Included the new tests in the main test run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->