### PR TITLE
feat: add traffic-aware polyline data to Google Routes API

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Maps/Google/Config.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Google/Config.hs
@@ -39,6 +39,7 @@ data GoogleCfg = GoogleCfg
 data GoogleRouteConfig = GoogleRouteConfig
   { computeAlternativeRoutes :: Bool,
     routePreference :: RoutingPreference,
+    extraComputations :: Maybe [ExtraComputationV2],
     url :: BaseUrl
   }
   deriving (Show, Eq, Generic, ToJSON, FromJSON, ToSchema, FromDhall)

--- a/lib/mobility-core/src/Kernel/External/Maps/Google/MapsClient.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Google/MapsClient.hs
@@ -367,6 +367,16 @@ transitDirectionsAPI entityId url key origin destination mode computeAlternative
     ApiCallLogger.pushExternalApiCallDataToKafka "transitDirectionsAPI" "Google" entityId (Just req) rsp
   checkGoogleMapsError' url rsp
 
+extraComputationFieldMaskSuffix :: GoogleMaps.ExtraComputationV2 -> Text
+extraComputationFieldMaskSuffix = \case
+  GoogleMaps.TRAFFIC_ON_POLYLINE -> ",routes.travelAdvisory.speedReadingIntervals"
+  GoogleMaps.TOLLS -> ",routes.travelAdvisory.tollInfo"
+  GoogleMaps.FUEL_CONSUMPTION -> ",routes.travelAdvisory.fuelConsumptionMicroliters"
+  GoogleMaps.HTML_FORMATTED_NAVIGATION_INSTRUCTIONS -> ",routes.legs.steps.navigationInstruction"
+  GoogleMaps.FLYOVER_INFO_ON_POLYLINE -> ",routes.polylineDetails.flyoverInfo"
+  GoogleMaps.NARROW_ROAD_INFO_ON_POLYLINE -> ",routes.polylineDetails.narrowRoadInfo"
+  GoogleMaps.EXTRA_COMPUTATION_UNSPECIFIED -> ""
+
 advancedDirectionsAPI ::
   ( CoreMetrics m,
     MonadFlow m,
@@ -384,12 +394,15 @@ advancedDirectionsAPI ::
   Bool ->
   Bool ->
   GoogleMaps.RoutingPreference ->
+  Maybe [GoogleMaps.ExtraComputationV2] ->
   m GoogleMaps.AdvancedDirectionsResp
-advancedDirectionsAPI entityId url key origin destination mode intermediates isAvoidTolls computeAlternativeRoutes routingPreference = do
+advancedDirectionsAPI entityId url key origin destination mode intermediates isAvoidTolls computeAlternativeRoutes routingPreference extraComputations = do
   let routeModifiers = GoogleMaps.RouteModifiers {avoidTolls = if isAvoidTolls then Just True else Nothing, avoidFerries = True}
       travelMode = mode
       req = GoogleMaps.AdvancedDirectionsReq {..}
-  rsp <- callAPI url (advancedDirectionsClient key "routes.legs.*,routes.distanceMeters,routes.duration,routes.staticDuration.*,routes.viewport.*,routes.polyline.*,routes.routeLabels.*,routes.routeToken" req) "advancedDirectionsAPI" (Proxy :: Proxy GoogleMapsAPI)
+      baseFieldMask = "routes.legs.*,routes.distanceMeters,routes.duration,routes.staticDuration.*,routes.viewport.*,routes.polyline.*,routes.routeLabels.*,routes.routeToken"
+      fieldMask = baseFieldMask <> foldMap extraComputationFieldMaskSuffix (fromMaybe [] extraComputations)
+  rsp <- callAPI url (advancedDirectionsClient key fieldMask req) "advancedDirectionsAPI" (Proxy :: Proxy GoogleMapsAPI)
   fork ("Logging external API Call of advancedDirectionsAPI Google ") $
     ApiCallLogger.pushExternalApiCallDataToKafka "advancedDirectionsAPI" "Google" entityId (Just req) rsp
   checkGoogleMapsError' url rsp

--- a/lib/mobility-core/src/Kernel/External/Maps/Google/MapsClient/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Google/MapsClient/Types.hs
@@ -416,10 +416,21 @@ data AdvancedDirectionsReq = AdvancedDirectionsReq
     routingPreference :: RoutingPreference,
     travelMode :: Maybe ModeV2,
     computeAlternativeRoutes :: Bool,
-    routeModifiers :: RouteModifiers
+    routeModifiers :: RouteModifiers,
+    extraComputations :: Maybe [ExtraComputationV2]
   }
   -----------remove null fields-----------
   deriving (Generic, ToJSON, FromJSON, ToSchema)
+
+data ExtraComputationV2
+  = EXTRA_COMPUTATION_UNSPECIFIED
+  | TRAFFIC_ON_POLYLINE
+  | TOLLS
+  | FUEL_CONSUMPTION
+  | HTML_FORMATTED_NAVIGATION_INSTRUCTIONS
+  | FLYOVER_INFO_ON_POLYLINE
+  | NARROW_ROAD_INFO_ON_POLYLINE
+  deriving (Eq, Show, Generic, ToJSON, FromJSON, ToSchema, FromDhall)
 
 newtype WayPointV2 = WayPointV2
   { ---- Union field location_type can be only one of the following:
@@ -486,9 +497,26 @@ data RouteV2 = RouteV2
     distanceMeters :: Int,
     duration :: Text,
     staticDuration :: Maybe Text,
-    routeToken :: Maybe Text
+    routeToken :: Maybe Text,
+    polyline :: Maybe Polyline,
+    travelAdvisory :: Maybe RouteTravelAdvisoryV2
   }
   deriving (Generic, ToJSON, FromJSON, ToSchema)
+
+newtype RouteTravelAdvisoryV2 = RouteTravelAdvisoryV2
+  { speedReadingIntervals :: Maybe [SpeedReadingIntervalV2]
+  }
+  deriving (Generic, ToJSON, FromJSON, ToSchema)
+
+data SpeedReadingIntervalV2 = SpeedReadingIntervalV2
+  { startPolylinePointIndex :: Maybe Int,
+    endPolylinePointIndex :: Maybe Int,
+    speed :: Maybe SpeedV2
+  }
+  deriving (Generic, ToJSON, FromJSON, ToSchema)
+
+data SpeedV2 = SPEED_UNSPECIFIED | NORMAL | SLOW | TRAFFIC_JAM
+  deriving (Eq, Show, Generic, ToJSON, FromJSON, ToSchema)
 
 data ViewPort = ViewPort
   { low :: LatLngV2,

--- a/lib/mobility-core/src/Kernel/External/Maps/Interface/Google.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Interface/Google.hs
@@ -164,12 +164,13 @@ getRoutes entityId isAvoidToll cfg req = do
           destination = NE.last waypointsV2
           intermediates = if length waypointsV2 > 2 then Just $ init $ NE.tail waypointsV2 else Nothing
           mode = getModeV2 <$> req.mode
-      result <- withTryCatch "getRoutes" $ GoogleMaps.advancedDirectionsAPI entityId googleMapsUrl key origin destination mode intermediates isAvoidToll computeAlternativeRoutes routePreference
+          extraComputations = cfg.googleRouteConfig.extraComputations
+      result <- withTryCatch "getRoutes" $ GoogleMaps.advancedDirectionsAPI entityId googleMapsUrl key origin destination mode intermediates isAvoidToll computeAlternativeRoutes routePreference extraComputations
       case result of
         Right gRes -> do
           if null gRes.routes && isAvoidToll
             then do
-              gResp <- GoogleMaps.advancedDirectionsAPI entityId googleMapsUrl key origin destination mode intermediates False computeAlternativeRoutes routePreference
+              gResp <- GoogleMaps.advancedDirectionsAPI entityId googleMapsUrl key origin destination mode intermediates False computeAlternativeRoutes routePreference extraComputations
               traverse (mkRoute' routeProxyReq) gResp.routes
             else traverse (mkRoute' routeProxyReq) gRes.routes
         Left err -> do
@@ -201,6 +202,24 @@ getRoutes entityId isAvoidToll cfg req = do
         BICYCLE -> GoogleMaps.BICYCLE
         MOTORCYCLE -> GoogleMaps.TWO_WHEELER
 
+mkTrafficSegments :: Maybe GoogleMaps.RouteTravelAdvisoryV2 -> Maybe [RouteTrafficSegment]
+mkTrafficSegments mbAdvisory = do
+  advisory <- mbAdvisory
+  intervals <- advisory.speedReadingIntervals
+  case mapMaybe convertInterval intervals of
+    [] -> Nothing
+    segs -> Just segs
+  where
+    convertInterval interval = do
+      endIdx <- interval.endPolylinePointIndex
+      sp <- interval.speed
+      let startIdx = fromMaybe 0 interval.startPolylinePointIndex
+      pure $ RouteTrafficSegment {startIndex = startIdx, endIndex = endIdx, speed = mapSpeed sp}
+    mapSpeed GoogleMaps.NORMAL = TrafficNormal
+    mapSpeed GoogleMaps.SLOW = TrafficSlow
+    mapSpeed GoogleMaps.TRAFFIC_JAM = TrafficJam
+    mapSpeed GoogleMaps.SPEED_UNSPECIFIED = TrafficUnspecified
+
 mkRoute' ::
   (MonadFlow m) =>
   GetRoutesReqProxy ->
@@ -211,7 +230,7 @@ mkRoute' req route = do
   if null route.legs
     then do
       logTagWarning "GoogleMapsDirections" ("Empty route.legs, " <> show req)
-      return $ RouteInfo Nothing Nothing Nothing Nothing bound [] [] Nothing
+      return $ RouteInfo Nothing Nothing Nothing Nothing bound [] [] Nothing Nothing
     else do
       when (length route.legs > 1) $
         logTagWarning "GoogleMapsDirections" ("More than one element in route.legs, " <> show req)
@@ -219,10 +238,14 @@ mkRoute' req route = do
       let totalDistance = Meters route.distanceMeters
           distanceWithUnit = Distance (toHighPrecDistance totalDistance) Meter
           allSteps = foldl (\acc leg -> acc ++ leg.steps) [] route.legs
-          polylinePoints = concatMap (\step -> decode step.polyline.encodedPolyline) allSteps
+          stepPolylinePoints = concatMap (\step -> decode step.polyline.encodedPolyline) allSteps
           totalStaticDuration = durationInS =<< route.staticDuration
+          mbTrafficSegments = mkTrafficSegments route.travelAdvisory
+          polylinePoints = case (mbTrafficSegments, route.polyline) of
+            (Just _, Just rp) -> decode rp.encodedPolyline
+            _ -> stepPolylinePoints
       totalDuration <- durationInS route.duration & fromMaybeM (InternalError "No duration value provided in advanced directions API response")
-      return $ RouteInfo (Just totalDuration) totalStaticDuration (Just totalDistance) (Just distanceWithUnit) bound [] polylinePoints route.routeToken
+      return $ RouteInfo (Just totalDuration) totalStaticDuration (Just totalDistance) (Just distanceWithUnit) bound [] polylinePoints route.routeToken mbTrafficSegments
   where
     mkBounds :: GoogleMaps.ViewPort -> BoundingBoxWithoutCRS
     mkBounds viewport =
@@ -245,7 +268,7 @@ mkRoute req route = do
   if null route.legs
     then do
       logTagWarning "GoogleMapsDirections" ("Empty route.legs, " <> show req)
-      return $ RouteInfo Nothing Nothing Nothing Nothing bound [] [] Nothing
+      return $ RouteInfo Nothing Nothing Nothing Nothing bound [] [] Nothing Nothing
     else do
       when (length route.legs > 1) $
         logTagWarning "GoogleMapsDirections" ("More than one element in route.legs, " <> show req)
@@ -258,8 +281,8 @@ mkRoute req route = do
       -- TODO: Fix snappedWayPoints: the waypoint passed in request which are snapped to road
       -- snappedWayPoints = (\step -> (LatLong step.start_location.lat step.start_location.lng, LatLong step.end_location.lat step.end_location.lng)) <$> steps
 
-      -- Basic Directions API does not return route tokens (Routes API v2 only).
-      return $ RouteInfo (Just totalDuration) Nothing (Just totalDistance) (Just distanceWithUnit) bound [] polylinePoints Nothing
+      -- Basic Directions API does not return route tokens or traffic (Routes API v2 only).
+      return $ RouteInfo (Just totalDuration) Nothing (Just totalDistance) (Just distanceWithUnit) bound [] polylinePoints Nothing Nothing
   where
     mkBounds :: GoogleMaps.Bounds -> BoundingBoxWithoutCRS
     mkBounds gBound =

--- a/lib/mobility-core/src/Kernel/External/Maps/Interface/MMI.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Interface/MMI.hs
@@ -218,7 +218,7 @@ mkRoute req resp route = do
   if null route.legs
     then do
       logTagWarning "MMIRoutes" ("Empty route.legs, " <> show req)
-      return $ RouteInfo Nothing Nothing Nothing Nothing bound [] [] Nothing
+      return $ RouteInfo Nothing Nothing Nothing Nothing bound [] [] Nothing Nothing
     else do
       when (length route.legs > 1) $
         logTagWarning "MMIRoutes" ("More than one element in route.legs, " <> show req)
@@ -229,7 +229,7 @@ mkRoute req resp route = do
           distanceInM = Just $ Meters $ double2Int route.distance
           distanceWithUnit = Just $ Distance (toHighPrecDistance route.distance) Meter
           durationInS = Just $ Seconds $ double2Int route.duration
-      return $ RouteInfo durationInS Nothing distanceInM distanceWithUnit boundBox snappedWayPoints points Nothing
+      return $ RouteInfo durationInS Nothing distanceInM distanceWithUnit boundBox snappedWayPoints points Nothing Nothing
   where
     createAcc = Acc {minLat = 91.0, maxLat = -91.0, minLon = 180.0, maxLon = -180.0}
     boundingBoxCal points = foldl' compareLatLong createAcc points

--- a/lib/mobility-core/src/Kernel/External/Maps/Interface/NextBillion.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Interface/NextBillion.hs
@@ -60,7 +60,8 @@ convertToRoute route =
       boundingBox = Nothing,
       snappedWaypoints = [],
       points = PP.decode $ route.geometry,
-      routeToken = Nothing
+      routeToken = Nothing,
+      trafficSegments = Nothing
     }
 
 latLongToPlace :: LatLong -> GoogleMaps.Place

--- a/lib/mobility-core/src/Kernel/External/Maps/Interface/OSRM.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Interface/OSRM.hs
@@ -190,7 +190,8 @@ convertRouteToRouteInfo osrmRouteRoutes =
             points = map (.getLatLong) osrmRouteRoutes.geometry.coordinates,
             snappedWaypoints = map (\steps -> getLatLong $ head steps.geometry.coordinates) $ OSRM.steps $ head osrmRouteRoutes.legs,
             boundingBox = Nothing,
-            routeToken = Nothing
+            routeToken = Nothing,
+            trafficSegments = Nothing
           }
 
 getOSRMRoute ::

--- a/lib/mobility-core/src/Kernel/External/Maps/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Interface/Types.hs
@@ -119,8 +119,19 @@ data RouteInfo = RouteInfo
     boundingBox :: Maybe BoundingBoxWithoutCRS,
     snappedWaypoints :: [LatLong],
     points :: [LatLong],
-    routeToken :: Maybe Text
+    routeToken :: Maybe Text,
+    trafficSegments :: Maybe [RouteTrafficSegment]
   }
+  deriving (Generic, ToJSON, FromJSON, ToSchema, Show, Eq, Ord)
+
+data RouteTrafficSegment = RouteTrafficSegment
+  { startIndex :: Int,
+    endIndex :: Int,
+    speed :: TrafficSpeed
+  }
+  deriving (Generic, ToJSON, FromJSON, ToSchema, Show, Eq, Ord)
+
+data TrafficSpeed = TrafficNormal | TrafficSlow | TrafficJam | TrafficUnspecified
   deriving (Generic, ToJSON, FromJSON, ToSchema, Show, Eq, Ord)
 
 instance FromField RouteInfo where


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Route results can now include optional traffic segment details (start/end indices and traffic speed category).
  * Google advanced directions can request and surface traffic-on-polyline information when configured.

* **Bug Fixes**
  * Improved consistency of route responses across mapping providers, including consistent handling of missing/empty route legs and tokens.
  * Added more reliable fallback behavior when advanced route data is unavailable.

* **Chores**
  * Extended shared route models to carry traffic segment data end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->