### PR TITLE
Backend:fix: added xyneWebhook signing secret in msc config

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Ticket/XyneSpaces/Config.hs
+++ b/lib/mobility-core/src/Kernel/External/Ticket/XyneSpaces/Config.hs
@@ -30,6 +30,7 @@ data XyneSpacesCfg = XyneSpacesCfg
     xyneAgentUserId :: Text,
     -- | Strip HTML from inbound reply bodies before persisting as the chat
     -- @message@ field. Defaults to True on read when omitted from JSON.
-    convertHtmlToPlainText :: Maybe Bool
+    convertHtmlToPlainText :: Maybe Bool,
+    xyneWebhookSigningSecret :: Maybe (EncryptedField 'AsEncrypted Text)
   }
   deriving (Show, Eq, Generic, ToJSON, FromJSON)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional webhook signing secret setting for XyneSpaces integrations.
  * Existing HTML-to-plain-text configuration remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->