### PR TITLE
Revert "Backend:fix: added xyneWebhook signing secret in msc config"

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Ticket/XyneSpaces/Config.hs
+++ b/lib/mobility-core/src/Kernel/External/Ticket/XyneSpaces/Config.hs
@@ -30,7 +30,6 @@ data XyneSpacesCfg = XyneSpacesCfg
     xyneAgentUserId :: Text,
     -- | Strip HTML from inbound reply bodies before persisting as the chat
     -- @message@ field. Defaults to True on read when omitted from JSON.
-    convertHtmlToPlainText :: Maybe Bool,
-    xyneWebhookSigningSecret :: Maybe (EncryptedField 'AsEncrypted Text)
+    convertHtmlToPlainText :: Maybe Bool
   }
   deriving (Show, Eq, Generic, ToJSON, FromJSON)


### PR DESCRIPTION
Reverts nammayatri/shared-kernel#1416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an obsolete configuration option from the XyneSpaces integration.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->