### PR TITLE
backend/fix/idfy-parse-error-for-blacklist_status

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/Types/Response.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/Types/Response.hs
@@ -205,7 +205,7 @@ data RCVerificationOutput = RCVerificationOutput
     permit_validity_from :: Maybe Text,
     puc_number :: Maybe A.Value,
     owner_mobile_no :: Maybe A.Value,
-    blacklist_status :: Maybe Text,
+    blacklist_status :: Maybe A.Value,
     body_type :: Maybe Text,
     unladden_weight :: Maybe A.Value,
     insurance_name :: Maybe Text,

--- a/lib/mobility-core/src/Kernel/External/Verification/Idfy/WebhookHandler.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Idfy/WebhookHandler.hs
@@ -57,5 +57,6 @@ webhookHandler cfg verifyHandler secret val = do
                 pure Ack
               Nothing -> pure Ack
           DAT.Error err -> do
-            logInfo $ "Error 2: " <> show err
+            logError $ "Error 2: " <> show err
+            logInfo $ "Failed to parse Idfy webhook payload; dropping it. Payload=" <> respDump
             pure Ack


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of verification output by accepting different formats for blacklist status data.
  * Enhanced webhook payload parsing error handling: failures now log the specific parse error at error level and include an info log that the payload is being dropped, along with a serialized dump of the rejected payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->