### PR TITLE
backend/fix: stripe webhook content type

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Stripe.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Stripe.hs
@@ -22,6 +22,7 @@ import qualified Kernel.Types.Beckn.Context as Context
 import Kernel.Types.Common
 import Kernel.Types.Error
 import Kernel.Types.Id
+import Kernel.Types.Servant (RawByteString (..))
 import Kernel.Utils.Common
 
 createConnectAccount ::
@@ -569,7 +570,7 @@ serviceEventWebhook ::
   (Id Stripe.Event -> m Bool) ->
   (Events.ServiceEventResp -> Text -> m AckResponse) ->
   Maybe Text ->
-  Stripe.RawByteString ->
+  RawByteString ->
   m AckResponse
 serviceEventWebhook paymentConfig checkDuplicatedEvent serviceEventHandler mbSigHeader rawBytes = do
   Stripe.serviceEventWebhook paymentConfig checkDuplicatedEvent (\resp respDump -> buildServiceEventResp resp >>= flip serviceEventHandler respDump) mbSigHeader rawBytes

--- a/lib/mobility-core/src/Kernel/External/Payment/Stripe/Webhook.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Stripe/Webhook.hs
@@ -16,7 +16,6 @@ module Kernel.External.Payment.Stripe.Webhook
   ( StripeWebhookAPI,
     serviceEventWebhook,
     verifyStripeWebhookSignature,
-    RawByteString (..),
   )
 where
 
@@ -28,7 +27,6 @@ import Data.ByteArray.Encoding (Base (Base16), convertFromBase, convertToBase)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as LBS
-import Data.OpenApi hiding (Header, get)
 import qualified Data.Text as T
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Data.Tuple.Extra (both)
@@ -39,27 +37,15 @@ import Kernel.Prelude
 import Kernel.Types.Error
 import Kernel.Types.HideSecrets
 import Kernel.Types.Id
+import Kernel.Types.Servant (RawByteString (..), RawJson)
 import Kernel.Utils.Common
 import Servant hiding (throwError)
-import qualified Servant.API as S
 
 type StripeWebhookAPI =
   "service" :> "stripe" :> "payment"
     :> Header "Stripe-Signature" Text
-    :> ReqBody '[OctetStream] RawByteString -- we need raw bytes for proper signature check
+    :> ReqBody '[RawJson] RawByteString -- raw bytes for signature check; Stripe sends application/json
     :> Post '[JSON] AckResponse
-
--- openapi lib does not provide instance for ByteString, so need to define newtype
-newtype RawByteString = RawByteString {getRawByteString :: LBS.ByteString}
-
-instance ToSchema RawByteString where
-  declareNamedSchema _ = pure $ NamedSchema (Just "RawByteString") byteSchema
-
-instance S.MimeRender OctetStream RawByteString where
-  mimeRender _ = getRawByteString
-
-instance S.MimeUnrender OctetStream RawByteString where
-  mimeUnrender _ = Right . RawByteString
 
 serviceEventWebhook ::
   EncFlow m r =>

--- a/lib/mobility-core/src/Kernel/External/Payout/Interface/Stripe.hs
+++ b/lib/mobility-core/src/Kernel/External/Payout/Interface/Stripe.hs
@@ -17,7 +17,6 @@ import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Kernel.External.Encryption
 import Kernel.External.Payment.Interface.Stripe (centsToUsd, eurToCents, usdToCents)
 import Kernel.External.Payment.Stripe.Types.Common (Event)
-import Kernel.External.Payment.Stripe.Webhook (RawByteString (..))
 import qualified Kernel.External.Payout.Interface.Events.Types as Events
 import Kernel.External.Payout.Interface.Types as IPayout
 import qualified Kernel.External.Payout.Juspay.Types.Payout as Juspay
@@ -31,6 +30,7 @@ import qualified Kernel.Tools.Metrics.CoreMetrics as Metrics
 import Kernel.Types.Beckn.Ack
 import Kernel.Types.Error
 import Kernel.Types.Id
+import Kernel.Types.Servant (RawByteString (..))
 import Kernel.Utils.Common
 
 createExternalPayout ::

--- a/lib/mobility-core/src/Kernel/External/Payout/Stripe/Webhook.hs
+++ b/lib/mobility-core/src/Kernel/External/Payout/Stripe/Webhook.hs
@@ -3,13 +3,12 @@
 module Kernel.External.Payout.Stripe.Webhook
   ( PayoutStripeWebhookAPI,
     payoutServiceEventWebhook,
-    RawByteString (..),
   )
 where
 
 import qualified Data.Aeson as A
 import Kernel.External.Payment.Stripe.Types.Common (Event)
-import Kernel.External.Payment.Stripe.Webhook (RawByteString (..), verifyStripeWebhookSignature)
+import Kernel.External.Payment.Stripe.Webhook (verifyStripeWebhookSignature)
 import Kernel.External.Payout.Interface.Types
 import qualified Kernel.External.Payout.Stripe.Types.Webhook as PayoutWh
 import Kernel.Prelude
@@ -17,13 +16,14 @@ import Kernel.Types.Beckn.Ack
 import Kernel.Types.Error
 import Kernel.Types.HideSecrets
 import Kernel.Types.Id
+import Kernel.Types.Servant (RawByteString (..), RawJson)
 import Kernel.Utils.Common
 import Servant hiding (throwError)
 
 type PayoutStripeWebhookAPI =
   "service" :> "stripe" :> "payout"
     :> Header "Stripe-Signature" Text
-    :> ReqBody '[OctetStream] RawByteString
+    :> ReqBody '[RawJson] RawByteString
     :> Post '[JSON] AckResponse
 
 payoutServiceEventWebhook ::

--- a/lib/mobility-core/src/Kernel/External/Ticket/XyneSpaces/Webhook.hs
+++ b/lib/mobility-core/src/Kernel/External/Ticket/XyneSpaces/Webhook.hs
@@ -29,44 +29,10 @@ import Data.ByteArray (constEq)
 import Data.ByteArray.Encoding (Base (Base16), convertFromBase, convertToBase)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.List.NonEmpty as NE
-import Data.OpenApi (NamedSchema (NamedSchema), ToSchema (..), byteSchema)
 import Kernel.Prelude
 import Kernel.Types.Error
+import Kernel.Types.Servant (RawByteString (..), RawJson)
 import Kernel.Utils.Common
-import Network.HTTP.Media ((//))
-import Servant hiding (throwError)
-import qualified Servant.API as S
-
--- | OpenApi/Servant wrapper so the inbound webhook route can receive raw
--- bytes for signature verification (JSON parsing happens after verify).
-newtype RawByteString = RawByteString {getRawByteString :: LBS.ByteString}
-
-instance ToSchema RawByteString where
-  declareNamedSchema _ = pure $ NamedSchema (Just "RawByteString") byteSchema
-
-instance S.MimeRender OctetStream RawByteString where
-  mimeRender _ = getRawByteString
-
-instance S.MimeUnrender OctetStream RawByteString where
-  mimeUnrender _ = Right . RawByteString
-
--- | Content type that advertises @application/json@ on the wire (so Servant
--- routes the request when Xyne sends @Content-Type: application/json@) but
--- keeps the body as raw bytes for HMAC verification.
---
--- Defining a fresh 'Accept'-tagged type avoids the overlap with Servant's
--- generic @FromJSON a => MimeUnrender JSON a@ instance.
-data RawJson
-
-instance Accept RawJson where
-  contentTypes _ = NE.fromList ["application" // "json", "application" // "*"]
-
-instance S.MimeRender RawJson RawByteString where
-  mimeRender _ = getRawByteString
-
-instance S.MimeUnrender RawJson RawByteString where
-  mimeUnrender _ = Right . RawByteString
 
 -- | Verify the @X-Xyne-Signature@ header for a raw webhook body using the
 -- shared signing secret. Throws @InvalidRequest@ on mismatch.

--- a/lib/mobility-core/src/Kernel/Types/Servant.hs
+++ b/lib/mobility-core/src/Kernel/Types/Servant.hs
@@ -12,13 +12,51 @@
   General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 -}
 
-module Kernel.Types.Servant where
+module Kernel.Types.Servant
+  ( PlainText_ISO_8859_1,
+    RawByteString (..),
+    RawJson,
+  )
+where
 
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.List.NonEmpty as NE
+import Data.OpenApi (NamedSchema (NamedSchema), ToSchema (..), byteSchema)
 import EulerHS.Prelude hiding (encodeUtf8, fromStrict, toStrict)
 import qualified Network.HTTP.Media as M
 import Servant
+import qualified Servant.API as S
 
 data PlainText_ISO_8859_1 deriving (Typeable)
 
 instance Accept PlainText_ISO_8859_1 where
   contentType _ = "text" M.// "plain" M./: ("charset", "ISO-8859-1")
+
+-- | OpenApi/Servant wrapper so inbound webhook routes can receive raw bytes for
+-- signature verification (JSON parsing happens after verify).
+newtype RawByteString = RawByteString {getRawByteString :: LBS.ByteString}
+
+instance ToSchema RawByteString where
+  declareNamedSchema _ = pure $ NamedSchema (Just "RawByteString") byteSchema
+
+instance S.MimeRender OctetStream RawByteString where
+  mimeRender _ = getRawByteString
+
+instance S.MimeUnrender OctetStream RawByteString where
+  mimeUnrender _ = Right . RawByteString
+
+-- | Content type that advertises @application/json@ on the wire while keeping
+-- the body as raw bytes for HMAC verification.
+--
+-- Defining a fresh 'Accept'-tagged type avoids the overlap with Servant's
+-- generic @FromJSON a => MimeUnrender JSON a@ instance.
+data RawJson
+
+instance Accept RawJson where
+  contentTypes _ = NE.fromList ["application" M.// "json", "application" M.// "*"]
+
+instance S.MimeRender RawJson RawByteString where
+  mimeRender _ = getRawByteString
+
+instance S.MimeUnrender RawJson RawByteString where
+  mimeUnrender _ = Right . RawByteString


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved webhook handling for Stripe payments, Stripe payouts, and Xyne Spaces.
  * Webhook requests can now be received as raw bytes while being advertised as JSON, supporting reliable signature verification.
* **Bug Fixes**
  * Standardized raw webhook payload processing across supported integrations.
  * Preserved the original request body during verification instead of relying on parsed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->