### PR TITLE
feat: add Kernel.External.Meta (whatsapp API client)

### DIFF
--- a/lib/mobility-core/mobility-core.cabal
+++ b/lib/mobility-core/mobility-core.cabal
@@ -149,6 +149,13 @@ library
       Kernel.External.Maps.Types
       Kernel.External.Maps.Utils
       Kernel.External.MasterCloudForward
+      Kernel.External.Meta
+      Kernel.External.Meta.Api
+      Kernel.External.Meta.Config
+      Kernel.External.Meta.Error
+      Kernel.External.Meta.Flow
+      Kernel.External.Meta.Types
+      Kernel.External.Meta.Webhook
       Kernel.External.MultiModal
       Kernel.External.MultiModal.Interface
       Kernel.External.MultiModal.Interface.Google

--- a/lib/mobility-core/src/Kernel/External/Meta.hs
+++ b/lib/mobility-core/src/Kernel/External/Meta.hs
@@ -1,0 +1,236 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+-- | Facade for the Meta WhatsApp Cloud API: the only module business code needs
+-- to import. Re-exports the config/types/error/webhook surface and provides
+-- smart constructors that hardcode every wire constant (messaging_product,
+-- recipient_type, the interactive/header discriminators) and truncate every
+-- text field to Meta's documented length caps. Builders are total (truncate,
+-- don't error). STRUCTURAL invariants that Meta enforces but a total builder
+-- cannot express without erroring — >=1 (and <=3) reply buttons, unique button
+-- ids/titles after truncation, >=1 row per section, and section.title being
+-- required only when there is more than one section — are the CALLER's
+-- responsibility (validate before send); the builder truncates but never rejects.
+module Kernel.External.Meta
+  ( module Kernel.External.Meta.Config,
+    module Kernel.External.Meta.Types,
+    module Kernel.External.Meta.Error,
+    module Kernel.External.Meta.Webhook,
+    mkTextMessage,
+    mkInteractiveButtonsMessage,
+    mkInteractiveListMessage,
+    mkLocationRequestMessage,
+    mkVideoMessage,
+    sendText,
+    sendInteractiveButtons,
+    sendInteractiveList,
+    sendLocationRequest,
+    sendVideo,
+  )
+where
+
+import qualified Data.Text as T
+import Kernel.External.Meta.Config
+import Kernel.External.Meta.Error
+import qualified Kernel.External.Meta.Flow as Flow
+import Kernel.External.Meta.Types
+import Kernel.External.Meta.Webhook
+import Kernel.Prelude
+import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
+import Kernel.Types.Common
+import Kernel.Utils.Common (HasRequestId)
+
+--------------------------------------------------------------------------------
+-- Smart constructors — wire constants live here, not in the types.
+--------------------------------------------------------------------------------
+
+-- | Common outbound envelope. context / biz_opaque_callback_data are omitted
+-- (no golden uses them outbound) and can be layered later.
+mkReq :: Text -> Text -> Maybe MetaTextBody -> Maybe MetaInteractive -> Maybe MetaVideo -> MetaSendMessageReq
+mkReq toNum typ mText mInteractive mVideo =
+  MetaSendMessageReq
+    { messagingProduct = "whatsapp",
+      recipientType = Just "individual",
+      to = toNum,
+      type_ = typ,
+      text = mText,
+      interactive = mInteractive,
+      video = mVideo,
+      context = Nothing,
+      bizOpaqueCallbackData = Nothing
+    }
+
+mkTextObj :: Text -> MetaTextObject
+mkTextObj t = MetaTextObject {text = t}
+
+mkTextHeader :: Text -> MetaHeader
+mkTextHeader t =
+  MetaHeader {type_ = "text", text = Just (T.take 60 t), image = Nothing, video = Nothing, document = Nothing}
+
+-- | Plain text message. previewUrl toggles link preview.
+mkTextMessage :: Text -> Text -> Maybe Bool -> MetaSendMessageReq
+mkTextMessage toNum bodyText previewUrl =
+  mkReq toNum "text" (Just MetaTextBody {body = T.take 4096 bodyText, previewUrl = previewUrl}) Nothing Nothing
+
+-- | Reply-buttons interactive. Caps: id<=256, title<=20, at most 3 buttons
+-- (mirrors whatsapp.ts truncation).
+mkInteractiveButtonsMessage :: Text -> Maybe Text -> Text -> Maybe Text -> [(Text, Text)] -> MetaSendMessageReq
+mkInteractiveButtonsMessage toNum mHeader bodyText mFooter btns =
+  mkReq toNum "interactive" Nothing (Just interactive) Nothing
+  where
+    interactive =
+      MetaInteractive
+        { type_ = "button",
+          header = mkTextHeader <$> mHeader,
+          body = mkTextObj (T.take 1024 bodyText),
+          footer = mkTextObj . T.take 60 <$> mFooter,
+          action =
+            MetaInteractiveAction
+              { buttons = Just (map mkBtn (take 3 btns)),
+                button = Nothing,
+                sections = Nothing,
+                name = Nothing
+              }
+        }
+    mkBtn (bid, btitle) =
+      MetaReplyButton
+        { type_ = "reply",
+          reply = MetaButtonRef {id = T.take 256 bid, title = T.take 20 btitle}
+        }
+
+-- | List-message interactive. Caps: button label<=20, row id<=200, row
+-- title<=24, row description<=72, at most 10 rows total across sections.
+-- Each section is (sectionTitle, [(rowId, rowTitle, rowDescription)]).
+mkInteractiveListMessage ::
+  Text ->
+  Maybe Text ->
+  Text ->
+  Maybe Text ->
+  Text ->
+  [(Maybe Text, [(Text, Text, Maybe Text)])] ->
+  MetaSendMessageReq
+mkInteractiveListMessage toNum mHeader bodyText mFooter buttonLabel rawSections =
+  mkReq toNum "interactive" Nothing (Just interactive) Nothing
+  where
+    interactive =
+      MetaInteractive
+        { type_ = "list",
+          header = mkTextHeader <$> mHeader,
+          body = mkTextObj (T.take 4096 bodyText),
+          footer = mkTextObj . T.take 60 <$> mFooter,
+          action =
+            MetaInteractiveAction
+              { buttons = Nothing,
+                button = Just (T.take 20 buttonLabel),
+                sections = Just (buildSections rawSections),
+                name = Nothing
+              }
+        }
+
+buildSections :: [(Maybe Text, [(Text, Text, Maybe Text)])] -> [MetaListSection]
+buildSections = go (10 :: Int)
+  where
+    go _ [] = []
+    go budget ((stitle, rws) : rest)
+      | budget <= 0 = []
+      | otherwise =
+        let taken = take budget rws
+            sec = MetaListSection {title = T.take 24 <$> stitle, rows = map mkRow taken}
+         in sec : go (budget - length taken) rest
+    mkRow (rid, rtitle, rdesc) =
+      MetaListRow
+        { id = T.take 200 rid,
+          title = T.take 24 rtitle,
+          description = T.take 72 <$> rdesc
+        }
+
+-- | Location-request interactive. Meta rejects header/footer here, so they are
+-- forced Nothing; action.name is the fixed "send_location".
+mkLocationRequestMessage :: Text -> Text -> MetaSendMessageReq
+mkLocationRequestMessage toNum bodyText =
+  mkReq toNum "interactive" Nothing (Just interactive) Nothing
+  where
+    interactive =
+      MetaInteractive
+        { type_ = "location_request_message",
+          header = Nothing,
+          body = mkTextObj (T.take 1024 bodyText),
+          footer = Nothing,
+          action =
+            MetaInteractiveAction
+              { buttons = Nothing,
+                button = Nothing,
+                sections = Nothing,
+                name = Just "send_location"
+              }
+        }
+
+-- | Video message. XOR link/media-id enforced by the Either; caption<=1024.
+mkVideoMessage :: Text -> Either Text Text -> Maybe Text -> MetaSendMessageReq
+mkVideoMessage toNum linkOrId mCaption =
+  mkReq toNum "video" Nothing Nothing (Just video)
+  where
+    video = case linkOrId of
+      Left lnk -> MetaVideo {link = Just lnk, id = Nothing, caption = capped}
+      Right mid -> MetaVideo {link = Nothing, id = Just mid, caption = capped}
+    capped = T.take 1024 <$> mCaption
+
+--------------------------------------------------------------------------------
+-- Thin senders (construct + send).
+--------------------------------------------------------------------------------
+
+type SendMessageFlow m r =
+  ( CoreMetrics m,
+    MonadFlow m,
+    EncFlow m r,
+    HasRequestId r,
+    MonadReader r m
+  )
+
+sendText :: SendMessageFlow m r => MetaCfg -> Text -> Text -> Maybe Bool -> m MetaSendMessageResp
+sendText cfg toNum bodyText previewUrl =
+  Flow.sendMessage cfg (mkTextMessage toNum bodyText previewUrl)
+
+sendInteractiveButtons ::
+  SendMessageFlow m r =>
+  MetaCfg ->
+  Text ->
+  Maybe Text ->
+  Text ->
+  Maybe Text ->
+  [(Text, Text)] ->
+  m MetaSendMessageResp
+sendInteractiveButtons cfg toNum mHeader bodyText mFooter btns =
+  Flow.sendMessage cfg (mkInteractiveButtonsMessage toNum mHeader bodyText mFooter btns)
+
+sendInteractiveList ::
+  SendMessageFlow m r =>
+  MetaCfg ->
+  Text ->
+  Maybe Text ->
+  Text ->
+  Maybe Text ->
+  Text ->
+  [(Maybe Text, [(Text, Text, Maybe Text)])] ->
+  m MetaSendMessageResp
+sendInteractiveList cfg toNum mHeader bodyText mFooter buttonLabel secs =
+  Flow.sendMessage cfg (mkInteractiveListMessage toNum mHeader bodyText mFooter buttonLabel secs)
+
+sendLocationRequest :: SendMessageFlow m r => MetaCfg -> Text -> Text -> m MetaSendMessageResp
+sendLocationRequest cfg toNum bodyText =
+  Flow.sendMessage cfg (mkLocationRequestMessage toNum bodyText)
+
+sendVideo :: SendMessageFlow m r => MetaCfg -> Text -> Either Text Text -> Maybe Text -> m MetaSendMessageResp
+sendVideo cfg toNum linkOrId mCaption =
+  Flow.sendMessage cfg (mkVideoMessage toNum linkOrId mCaption)

--- a/lib/mobility-core/src/Kernel/External/Meta/Api.hs
+++ b/lib/mobility-core/src/Kernel/External/Meta/Api.hs
@@ -1,0 +1,32 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.Meta.Api where
+
+import EulerHS.Prelude
+import Kernel.External.Meta.Types
+import Servant
+
+-- POST https://graph.facebook.com/{version}/{phoneNumberId}/messages
+-- Authorization: Bearer <token>
+type MetaSendMessageAPI =
+  Capture "version" Text
+    :> Capture "phoneNumberId" Text
+    :> "messages"
+    :> Header "Authorization" Text
+    :> ReqBody '[JSON] MetaSendMessageReq
+    :> Post '[JSON] MetaSendMessageResp
+
+metaSendMessageAPI :: Proxy MetaSendMessageAPI
+metaSendMessageAPI = Proxy

--- a/lib/mobility-core/src/Kernel/External/Meta/Config.hs
+++ b/lib/mobility-core/src/Kernel/External/Meta/Config.hs
@@ -1,0 +1,61 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.Meta.Config where
+
+import Kernel.External.Encryption
+import Kernel.Prelude
+import Kernel.Utils.JSON
+import qualified Text.Show as TShow
+
+-- | Configuration for the Meta WhatsApp Cloud API.
+-- The outbound access token is encrypted-at-rest (decrypted only at call time in Flow.hs).
+-- verifyToken / appSecret are consumed by the inbound-webhook layer (later phase).
+data MetaCfg = MetaCfg
+  { accessToken :: EncryptedField 'AsEncrypted Text,
+    baseUrl :: BaseUrl, -- https://graph.facebook.com
+    phoneNumberId :: Text,
+    apiVersion :: Text, -- e.g. "v23.0" — configurable, never hard-coded
+    verifyToken :: Maybe Text, -- webhook GET handshake (consumed by app later)
+    appSecret :: Maybe Text -- webhook HMAC secret (consumed by app later)
+  }
+  deriving (Eq, Generic)
+
+-- Custom Show that REDACTS the plaintext webhook secrets (verifyToken,
+-- appSecret) so they can never leak into logs/traces. accessToken is an
+-- EncryptedField whose own Show already shows only the ciphertext.
+instance Show MetaCfg where
+  show MetaCfg {..} =
+    "MetaCfg {accessToken = " <> TShow.show accessToken
+      <> ", baseUrl = "
+      <> TShow.show baseUrl
+      <> ", phoneNumberId = "
+      <> TShow.show phoneNumberId
+      <> ", apiVersion = "
+      <> TShow.show apiVersion
+      <> ", verifyToken = "
+      <> redactMaybe verifyToken
+      <> ", appSecret = "
+      <> redactMaybe appSecret
+      <> "}"
+    where
+      redactMaybe :: Maybe Text -> String
+      redactMaybe Nothing = "Nothing"
+      redactMaybe (Just _) = "Just \"<redacted>\""
+
+instance FromJSON MetaCfg where
+  parseJSON = genericParseJSON constructorsWithSnakeCase
+
+instance ToJSON MetaCfg where
+  toJSON = genericToJSON constructorsWithSnakeCase

--- a/lib/mobility-core/src/Kernel/External/Meta/Config.hs
+++ b/lib/mobility-core/src/Kernel/External/Meta/Config.hs
@@ -17,42 +17,19 @@ module Kernel.External.Meta.Config where
 import Kernel.External.Encryption
 import Kernel.Prelude
 import Kernel.Utils.JSON
-import qualified Text.Show as TShow
 
 -- | Configuration for the Meta WhatsApp Cloud API.
--- The outbound access token is encrypted-at-rest (decrypted only at call time in Flow.hs).
--- verifyToken / appSecret are consumed by the inbound-webhook layer (later phase).
+-- The outbound access token is encrypted-at-rest (decrypted only at call time in Flow.hs);
+-- its own 'Show' surfaces only the ciphertext, so a derived 'Show' is safe here.
+-- Inbound-webhook secrets (verify token, app secret) are app-level env config, not
+-- per-merchant, so they live in the consuming service rather than in this stored config.
 data MetaCfg = MetaCfg
   { accessToken :: EncryptedField 'AsEncrypted Text,
     baseUrl :: BaseUrl, -- https://graph.facebook.com
     phoneNumberId :: Text,
-    apiVersion :: Text, -- e.g. "v23.0" — configurable, never hard-coded
-    verifyToken :: Maybe Text, -- webhook GET handshake (consumed by app later)
-    appSecret :: Maybe Text -- webhook HMAC secret (consumed by app later)
+    apiVersion :: Text -- e.g. "v23.0" — configurable, never hard-coded
   }
-  deriving (Eq, Generic)
-
--- Custom Show that REDACTS the plaintext webhook secrets (verifyToken,
--- appSecret) so they can never leak into logs/traces. accessToken is an
--- EncryptedField whose own Show already shows only the ciphertext.
-instance Show MetaCfg where
-  show MetaCfg {..} =
-    "MetaCfg {accessToken = " <> TShow.show accessToken
-      <> ", baseUrl = "
-      <> TShow.show baseUrl
-      <> ", phoneNumberId = "
-      <> TShow.show phoneNumberId
-      <> ", apiVersion = "
-      <> TShow.show apiVersion
-      <> ", verifyToken = "
-      <> redactMaybe verifyToken
-      <> ", appSecret = "
-      <> redactMaybe appSecret
-      <> "}"
-    where
-      redactMaybe :: Maybe Text -> String
-      redactMaybe Nothing = "Nothing"
-      redactMaybe (Just _) = "Just \"<redacted>\""
+  deriving (Eq, Show, Generic)
 
 instance FromJSON MetaCfg where
   parseJSON = genericParseJSON constructorsWithSnakeCase

--- a/lib/mobility-core/src/Kernel/External/Meta/Error.hs
+++ b/lib/mobility-core/src/Kernel/External/Meta/Error.hs
@@ -1,0 +1,143 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Kernel.External.Meta.Error where
+
+import Data.Aeson
+import qualified Data.ByteString.Lazy as LBS
+import Kernel.External.Meta.Types (metaAesonOptions)
+import Kernel.Prelude hiding (error)
+import Kernel.Types.Error.BaseError
+import Kernel.Types.Error.BaseError.HTTPError
+import Kernel.Types.Error.BaseError.HTTPError.FromResponse (FromResponse (fromResponse))
+import Servant.Client (ResponseF (responseBody))
+
+-- Meta wraps API failures as {"error": {...}}.
+newtype MetaErrorResp = MetaErrorResp
+  { error :: MetaErrorBody
+  }
+  deriving (Eq, Show, Generic)
+
+instance FromJSON MetaErrorResp where
+  parseJSON = genericParseJSON metaAesonOptions
+
+instance ToJSON MetaErrorResp where
+  toJSON = genericToJSON metaAesonOptions
+
+data MetaErrorBody = MetaErrorBody
+  { message :: Maybe Text,
+    type_ :: Maybe Text,
+    code :: Maybe Int,
+    errorSubcode :: Maybe Int,
+    errorData :: Maybe Value,
+    fbtraceId :: Maybe Text
+  }
+  deriving (Eq, Show, Generic)
+
+instance FromJSON MetaErrorBody where
+  parseJSON = genericParseJSON metaAesonOptions
+
+instance ToJSON MetaErrorBody where
+  toJSON = genericToJSON metaAesonOptions
+
+data MetaErrorInfo = MetaErrorInfo
+  { errorCode :: Maybe Int,
+    errorSubcode :: Maybe Int,
+    errorMessage :: Maybe Text,
+    fbtraceId :: Maybe Text
+  }
+  deriving (Eq, Show)
+
+data MetaError
+  = MetaRateLimitHit MetaErrorInfo -- 130429 throughput / 80007 account / 4 app        RETRYABLE
+  | MetaPairRateLimitHit MetaErrorInfo -- 131056 pair rate limit / 131049 marketing lim RETRYABLE
+  | MetaReengagementWindowClosed MetaErrorInfo -- 131047: >24h — needs template          PERMANENT
+  | MetaRecipientUnavailable MetaErrorInfo -- 131026 undeliverable                        PERMANENT
+  | MetaInvalidRequest MetaErrorInfo -- 100 / 131008 / 131009 param errors                PERMANENT
+  | MetaAuthError MetaErrorInfo -- 0 / 190 / 3 / 10 token-permission                      PERMANENT until fixed
+  | MetaUnknownError MetaErrorInfo -- everything else incl. undecodable body
+  deriving (Eq, Show, IsBecknAPIError)
+
+metaErrorMessage :: MetaErrorInfo -> Text
+metaErrorMessage info =
+  fromMaybe "unknown" info.errorMessage
+    <> maybe "" (\c -> " [code " <> show c <> "]") info.errorCode
+
+classifyMetaError :: Maybe Int -> MetaErrorInfo -> MetaError
+classifyMetaError mCode info = case mCode of
+  Just c
+    | c `elem` [130429, 80007, 4] -> MetaRateLimitHit info
+    | c `elem` [131056, 131049] -> MetaPairRateLimitHit info
+    | c == 131047 -> MetaReengagementWindowClosed info
+    | c == 131026 -> MetaRecipientUnavailable info
+    | c `elem` [100, 131008, 131009] -> MetaInvalidRequest info
+    | c `elem` [0, 190, 3, 10] -> MetaAuthError info
+  _ -> MetaUnknownError info
+
+instanceExceptionWithParent 'HTTPException ''MetaError
+
+instance FromResponse MetaError where
+  -- Always return Just so extractApiError never degrades to a RawError:
+  -- decode the {"error":{...}} body if possible, else fall back to MetaUnknownError.
+  fromResponse resp = Just $ case decode (responseBody resp) :: Maybe MetaErrorResp of
+    Just (MetaErrorResp b) ->
+      classifyMetaError b.code (MetaErrorInfo b.code b.errorSubcode b.message b.fbtraceId)
+    -- Undecodable body: keep a truncated raw snippet so unexpected Meta
+    -- responses remain diagnosable in production.
+    Nothing ->
+      MetaUnknownError
+        (MetaErrorInfo Nothing Nothing (Just ("undecodable Meta response body: " <> show (LBS.take 500 (responseBody resp)))) Nothing)
+
+isRetryableMetaError :: MetaError -> Bool
+isRetryableMetaError = \case
+  MetaRateLimitHit _ -> True
+  MetaPairRateLimitHit _ -> True
+  _ -> False
+
+needsTemplateReopen :: MetaError -> Bool
+needsTemplateReopen = \case
+  MetaReengagementWindowClosed _ -> True
+  _ -> False
+
+instance IsBaseError MetaError where
+  toMessage = \case
+    MetaRateLimitHit info -> Just $ "Meta throughput/rate limit: " <> metaErrorMessage info
+    MetaPairRateLimitHit info -> Just $ "Meta pair rate limit: " <> metaErrorMessage info
+    MetaReengagementWindowClosed info -> Just $ "Meta 24h re-engagement window closed (needs template): " <> metaErrorMessage info
+    MetaRecipientUnavailable info -> Just $ "Meta recipient unavailable: " <> metaErrorMessage info
+    MetaInvalidRequest info -> Just $ "Meta invalid request: " <> metaErrorMessage info
+    MetaAuthError info -> Just $ "Meta auth/permission error: " <> metaErrorMessage info
+    MetaUnknownError info -> Just $ "Meta error: " <> metaErrorMessage info
+
+instance IsHTTPError MetaError where
+  toErrorCode = \case
+    MetaRateLimitHit _ -> "META_RATE_LIMIT_HIT"
+    MetaPairRateLimitHit _ -> "META_PAIR_RATE_LIMIT_HIT"
+    MetaReengagementWindowClosed _ -> "META_REENGAGEMENT_WINDOW_CLOSED"
+    MetaRecipientUnavailable _ -> "META_RECIPIENT_UNAVAILABLE"
+    MetaInvalidRequest _ -> "META_INVALID_REQUEST"
+    MetaAuthError _ -> "META_AUTH_ERROR"
+    MetaUnknownError _ -> "META_UNKNOWN_ERROR"
+  toHttpCode = \case
+    MetaRateLimitHit _ -> E503
+    MetaPairRateLimitHit _ -> E503
+    MetaReengagementWindowClosed _ -> E400
+    MetaRecipientUnavailable _ -> E400
+    MetaInvalidRequest _ -> E400
+    MetaAuthError _ -> E401
+    MetaUnknownError _ -> E500
+
+instance IsAPIError MetaError

--- a/lib/mobility-core/src/Kernel/External/Meta/Flow.hs
+++ b/lib/mobility-core/src/Kernel/External/Meta/Flow.hs
@@ -1,0 +1,54 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.Meta.Flow where
+
+import EulerHS.Prelude
+import qualified EulerHS.Types as ET
+import Kernel.External.Encryption (decrypt)
+import Kernel.External.Meta.Api
+import Kernel.External.Meta.Config
+import Kernel.External.Meta.Error (MetaError)
+import Kernel.External.Meta.Types
+import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
+import Kernel.Types.Common
+import Kernel.Types.Error ()
+import Kernel.Utils.Common
+
+sendMessage ::
+  ( CoreMetrics m,
+    MonadFlow m,
+    EncFlow m r,
+    HasRequestId r,
+    MonadReader r m
+  ) =>
+  MetaCfg ->
+  MetaSendMessageReq ->
+  m MetaSendMessageResp
+sendMessage cfg req = do
+  token <- decrypt cfg.accessToken
+  let authHeader = Just $ "Bearer " <> token
+      eulerClient = ET.client (Proxy @MetaSendMessageAPI) cfg.apiVersion cfg.phoneNumberId authHeader req
+  callMetaAPI cfg.baseUrl eulerClient "metaSendMessage" (Proxy @MetaSendMessageAPI)
+
+-- Non-2xx -> fromResponse @MetaError on the failure body -> throws a typed
+-- MetaError; transport errors -> ExternalAPICallError (Just "META_NOT_AVAILABLE").
+-- `identity`, not `id` (RecordDotPreprocessor + Kernel.Prelude hide `id`).
+callMetaAPI :: CallAPI m r api a
+callMetaAPI =
+  callApiUnwrappingApiError
+    (identity @MetaError)
+    Nothing
+    (Just "META_NOT_AVAILABLE")
+    Nothing

--- a/lib/mobility-core/src/Kernel/External/Meta/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Meta/Types.hs
@@ -1,0 +1,601 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.Meta.Types where
+
+import Data.Aeson
+import Kernel.Prelude
+import Kernel.Utils.JSON (camelToSnakeCase)
+
+--------------------------------------------------------------------------------
+-- Shared aeson options: ONE mechanism for every generic instance below.
+-- omitNothingFields works BOTH directions (encode drops Nothing; generic parse
+-- accepts absent keys for Maybe fields).
+--------------------------------------------------------------------------------
+
+metaFieldModifier :: String -> String
+metaFieldModifier "type_" = "type" -- reserved-word remap
+metaFieldModifier "object_" = "object" -- avoid clash with Data.Aeson.object
+metaFieldModifier s = camelToSnakeCase s
+
+metaAesonOptions :: Options
+metaAesonOptions =
+  defaultOptions
+    { fieldLabelModifier = metaFieldModifier,
+      omitNothingFields = True
+    }
+
+--------------------------------------------------------------------------------
+-- OUTBOUND: one envelope record + Maybe payload fields (KarixContent idiom).
+-- Wire constants (messaging_product, recipient_type, type) are set by the
+-- smart constructors in Kernel.External.Meta; illegal payload combos are
+-- prevented there, not by the type.
+--------------------------------------------------------------------------------
+
+data MetaSendMessageReq = MetaSendMessageReq
+  { messagingProduct :: Text, -- "messaging_product" = "whatsapp"
+    recipientType :: Maybe Text, -- "recipient_type" = Just "individual"
+    to :: Text,
+    type_ :: Text, -- "text" | "interactive" | "video"
+    text :: Maybe MetaTextBody,
+    interactive :: Maybe MetaInteractive,
+    video :: Maybe MetaVideo,
+    context :: Maybe MetaMessageContext,
+    bizOpaqueCallbackData :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaSendMessageReq where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaSendMessageReq where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaTextBody = MetaTextBody
+  { body :: Text,
+    previewUrl :: Maybe Bool -- "preview_url"
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaTextBody where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaTextBody where
+  parseJSON = genericParseJSON metaAesonOptions
+
+newtype MetaMessageContext = MetaMessageContext
+  { messageId :: Text -- "message_id"
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaMessageContext where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaMessageContext where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaInteractive = MetaInteractive
+  { type_ :: Text, -- "button" | "list" | "location_request_message"
+    header :: Maybe MetaHeader,
+    body :: MetaTextObject,
+    footer :: Maybe MetaTextObject,
+    action :: MetaInteractiveAction
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaInteractive where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaInteractive where
+  parseJSON = genericParseJSON metaAesonOptions
+
+newtype MetaTextObject = MetaTextObject
+  { text :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaTextObject where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaTextObject where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaHeader = MetaHeader
+  { type_ :: Text,
+    text :: Maybe Text,
+    image :: Maybe MetaMediaRef,
+    video :: Maybe MetaMediaRef,
+    document :: Maybe MetaMediaRef
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaHeader where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaHeader where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaMediaRef = MetaMediaRef
+  { id :: Maybe Text,
+    link :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaMediaRef where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaMediaRef where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaInteractiveAction = MetaInteractiveAction
+  { buttons :: Maybe [MetaReplyButton], -- reply-buttons shape
+    button :: Maybe Text, -- list shape (label)
+    sections :: Maybe [MetaListSection], -- list shape
+    name :: Maybe Text -- location_request shape = Just "send_location"
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaInteractiveAction where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaInteractiveAction where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaReplyButton = MetaReplyButton
+  { type_ :: Text, -- "reply"
+    reply :: MetaButtonRef
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaReplyButton where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaReplyButton where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaButtonRef = MetaButtonRef
+  { id :: Text,
+    title :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaButtonRef where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaButtonRef where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaListSection = MetaListSection
+  { title :: Maybe Text,
+    rows :: [MetaListRow]
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaListSection where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaListSection where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaListRow = MetaListRow
+  { id :: Text,
+    title :: Text,
+    description :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaListRow where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaListRow where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaVideo = MetaVideo
+  { link :: Maybe Text,
+    id :: Maybe Text,
+    caption :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaVideo where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaVideo where
+  parseJSON = genericParseJSON metaAesonOptions
+
+-- NOTE: the send-response is NOT one of the golden-verified units. Kept lenient
+-- (all-Maybe) and intentionally uncovered by a golden test. `id` on
+-- MetaRespMessage is the wamid — the only outbound correlation handle.
+data MetaSendMessageResp = MetaSendMessageResp
+  { messagingProduct :: Maybe Text,
+    contacts :: Maybe [MetaRespContact],
+    messages :: Maybe [MetaRespMessage]
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaSendMessageResp where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaSendMessageResp where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaRespContact = MetaRespContact
+  { input :: Maybe Text,
+    waId :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaRespContact where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaRespContact where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaRespMessage = MetaRespMessage
+  { id :: Text,
+    messageStatus :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaRespMessage where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaRespMessage where
+  parseJSON = genericParseJSON metaAesonOptions
+
+--------------------------------------------------------------------------------
+-- INBOUND: webhook envelope chain (generic except the two hand-written spots).
+--------------------------------------------------------------------------------
+
+data MetaWebhookEnvelope = MetaWebhookEnvelope
+  { object_ :: Text,
+    entry :: [MetaWebhookEntry]
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaWebhookEnvelope where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaWebhookEnvelope where
+  parseJSON = genericParseJSON metaAesonOptions
+
+-- NB: WhatsApp WABA entries carry no "time" field — do not add one.
+data MetaWebhookEntry = MetaWebhookEntry
+  { id :: Text,
+    changes :: [MetaWebhookChange]
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaWebhookEntry where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaWebhookEntry where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaWebhookChange = MetaWebhookChange
+  { value :: MetaChangeValue,
+    field :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaWebhookChange where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaWebhookChange where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaChangeValue = MetaChangeValue
+  { messagingProduct :: Text,
+    metadata :: MetaWebhookMetadata,
+    contacts :: Maybe [MetaContact],
+    messages :: Maybe [MetaInboundMessage],
+    statuses :: Maybe [MetaStatus],
+    errors :: Maybe [MetaWaError]
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaChangeValue where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaChangeValue where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaWebhookMetadata = MetaWebhookMetadata
+  { displayPhoneNumber :: Text,
+    phoneNumberId :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaWebhookMetadata where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaWebhookMetadata where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaContact = MetaContact
+  { profile :: Maybe MetaProfile,
+    waId :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaContact where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaContact where
+  parseJSON = genericParseJSON metaAesonOptions
+
+newtype MetaProfile = MetaProfile
+  { name :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaProfile where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaProfile where
+  parseJSON = genericParseJSON metaAesonOptions
+
+-- Unknown message type_ (reaction/image/...) still decodes; payloads all
+-- Nothing. NEVER fail on an unknown type. timestamp is a STRING epoch, keep it
+-- Text (never Int).
+data MetaInboundMessage = MetaInboundMessage
+  { from :: Text,
+    id :: Text,
+    timestamp :: Text,
+    type_ :: Text, -- raw discriminator retained
+    text :: Maybe MetaInboundText,
+    interactive :: Maybe MetaInteractiveReply,
+    location :: Maybe MetaInboundLocation,
+    context :: Maybe MetaInboundContext,
+    referral :: Maybe Value,
+    errors :: Maybe [Value]
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaInboundMessage where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaInboundMessage where
+  parseJSON = genericParseJSON metaAesonOptions
+
+newtype MetaInboundText = MetaInboundText
+  { body :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaInboundText where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaInboundText where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaInboundContext = MetaInboundContext
+  { from :: Maybe Text,
+    id :: Maybe Text,
+    forwarded :: Maybe Bool,
+    frequentlyForwarded :: Maybe Bool
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaInboundContext where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaInboundContext where
+  parseJSON = genericParseJSON metaAesonOptions
+
+-- latitude/longitude are JSON NUMBERS (Double), never strings.
+data MetaInboundLocation = MetaInboundLocation
+  { latitude :: Double,
+    longitude :: Double,
+    name :: Maybe Text,
+    address :: Maybe Text,
+    url :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaInboundLocation where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaInboundLocation where
+  parseJSON = genericParseJSON metaAesonOptions
+
+--------------------------------------------------------------------------------
+-- HAND-WRITTEN #1: interactive reply sum on interactive.type.
+-- The type-safety improvement over the TS ||-fallthrough. Unknown types decode
+-- to MetaUnknownReply (decode SUCCEEDS — batched envelopes must survive); the
+-- engine ignores them. Payload records are wrapped (no naked record fields in
+-- constructors) to avoid partial selectors under -Werror.
+--------------------------------------------------------------------------------
+
+data MetaInteractiveReply
+  = MetaButtonReply MetaButtonReplyData
+  | MetaListReply MetaListReplyData
+  | MetaUnknownReply Text
+  deriving (Show, Eq, Generic)
+
+data MetaButtonReplyData = MetaButtonReplyData
+  { id :: Text,
+    title :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaButtonReplyData where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaButtonReplyData where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaListReplyData = MetaListReplyData
+  { id :: Text,
+    title :: Text,
+    description :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaListReplyData where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaListReplyData where
+  parseJSON = genericParseJSON metaAesonOptions
+
+instance FromJSON MetaInteractiveReply where
+  parseJSON = withObject "MetaInteractiveReply" $ \o -> do
+    t <- o .: "type"
+    case (t :: Text) of
+      "button_reply" -> MetaButtonReply <$> o .: "button_reply"
+      "list_reply" -> MetaListReply <$> o .: "list_reply"
+      other -> pure (MetaUnknownReply other)
+
+instance ToJSON MetaInteractiveReply where
+  toJSON (MetaButtonReply d) = object ["type" .= ("button_reply" :: Text), "button_reply" .= d]
+  toJSON (MetaListReply d) = object ["type" .= ("list_reply" :: Text), "list_reply" .= d]
+  toJSON (MetaUnknownReply t) = object ["type" .= t]
+
+--------------------------------------------------------------------------------
+-- Statuses.
+--------------------------------------------------------------------------------
+
+data MetaStatus = MetaStatus
+  { id :: Text,
+    status :: MetaStatusValue,
+    timestamp :: Text,
+    recipientId :: Text,
+    recipientType :: Maybe Text,
+    bizOpaqueCallbackData :: Maybe Text,
+    conversation :: Maybe MetaConversation,
+    pricing :: Maybe MetaPricing,
+    errors :: Maybe [MetaWaError]
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaStatus where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaStatus where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaConversation = MetaConversation
+  { id :: Text,
+    expirationTimestamp :: Maybe Text,
+    origin :: Maybe MetaOrigin
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaConversation where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaConversation where
+  parseJSON = genericParseJSON metaAesonOptions
+
+newtype MetaOrigin = MetaOrigin
+  { type_ :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaOrigin where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaOrigin where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaPricing = MetaPricing
+  { billable :: Maybe Bool,
+    pricingModel :: Maybe Text,
+    type_ :: Maybe Text,
+    category :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaPricing where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaPricing where
+  parseJSON = genericParseJSON metaAesonOptions
+
+data MetaWaError = MetaWaError
+  { code :: Int,
+    title :: Maybe Text,
+    message :: Maybe Text,
+    errorData :: Maybe MetaErrorData,
+    href :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaWaError where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaWaError where
+  parseJSON = genericParseJSON metaAesonOptions
+
+newtype MetaErrorData = MetaErrorData
+  { details :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON MetaErrorData where
+  toJSON = genericToJSON metaAesonOptions
+
+instance FromJSON MetaErrorData where
+  parseJSON = genericParseJSON metaAesonOptions
+
+--------------------------------------------------------------------------------
+-- HAND-WRITTEN #2: status enum with unknown-tolerance (forward compat — MUST
+-- NOT fail on an unknown status).
+--------------------------------------------------------------------------------
+
+data MetaStatusValue
+  = MetaSent
+  | MetaDelivered
+  | MetaRead
+  | MetaFailed
+  | MetaPlayed
+  | MetaUnknownStatus Text
+  deriving (Show, Eq, Generic)
+
+instance FromJSON MetaStatusValue where
+  parseJSON = withText "MetaStatusValue" $ \t ->
+    pure $ case t of
+      "sent" -> MetaSent
+      "delivered" -> MetaDelivered
+      "read" -> MetaRead
+      "failed" -> MetaFailed
+      "played" -> MetaPlayed
+      other -> MetaUnknownStatus other
+
+instance ToJSON MetaStatusValue where
+  toJSON MetaSent = String "sent"
+  toJSON MetaDelivered = String "delivered"
+  toJSON MetaRead = String "read"
+  toJSON MetaFailed = String "failed"
+  toJSON MetaPlayed = String "played"
+  toJSON (MetaUnknownStatus t) = String t
+
+--------------------------------------------------------------------------------
+-- Dispatch: route on WHICH array is present, never on the `field` string.
+--------------------------------------------------------------------------------
+
+data MetaWebhookEvent
+  = EventMessages MetaWebhookMetadata [MetaContact] [MetaInboundMessage]
+  | EventStatuses [MetaStatus]
+  | EventErrors [MetaWaError]
+  | EventUnknown
+  deriving (Show, Eq, Generic)
+
+classifyChangeValue :: MetaChangeValue -> MetaWebhookEvent
+classifyChangeValue cv =
+  case (cv.messages, cv.statuses, cv.errors) of
+    (Just msgs, _, _) | not (null msgs) -> EventMessages cv.metadata (fromMaybe [] cv.contacts) msgs
+    (_, Just sts, _) | not (null sts) -> EventStatuses sts
+    (_, _, Just errs) | not (null errs) -> EventErrors errs
+    _ -> EventUnknown

--- a/lib/mobility-core/src/Kernel/External/Meta/Webhook.hs
+++ b/lib/mobility-core/src/Kernel/External/Meta/Webhook.hs
@@ -1,0 +1,121 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+-- | Helpers for the inbound Meta WhatsApp Cloud API webhook:
+--   * capture the raw request body (@RawByteString@) for signature verification,
+--   * verify @X-Hub-Signature-256@ (hex @HMAC_SHA256(rawBody, appSecret)@) with a
+--     constant-time comparison,
+--   * answer the GET @hub.challenge@ verification handshake.
+-- Self-contained duplicate of the Xyne webhook primitives (do not import across
+-- the Ticket namespace).
+module Kernel.External.Meta.Webhook where
+
+import Crypto.Hash (SHA256)
+import Crypto.MAC.HMAC (HMAC, hmac, hmacGetDigest)
+import Data.Aeson (eitherDecode)
+import Data.ByteArray (constEq)
+import Data.ByteArray.Encoding (Base (Base16), convertFromBase, convertToBase)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.List.NonEmpty as NE
+import Data.OpenApi (NamedSchema (NamedSchema), ToSchema (..), byteSchema)
+import qualified Data.Text as T
+import Kernel.External.Meta.Types (MetaWebhookEnvelope)
+import Kernel.Prelude
+import Kernel.Types.Error
+import Kernel.Utils.Common
+import Network.HTTP.Media ((//))
+import Servant hiding (throwError)
+import qualified Servant.API as S
+
+-- | OpenApi/Servant wrapper so the inbound webhook route can receive raw bytes
+-- for signature verification (JSON parsing happens after verify).
+newtype RawByteString = RawByteString {getRawByteString :: LBS.ByteString}
+
+instance ToSchema RawByteString where
+  declareNamedSchema _ = pure $ NamedSchema (Just "RawByteString") byteSchema
+
+instance S.MimeRender OctetStream RawByteString where
+  mimeRender _ = getRawByteString
+
+instance S.MimeUnrender OctetStream RawByteString where
+  mimeUnrender _ = Right . RawByteString
+
+-- | Content type that advertises @application/json@ on the wire (so Servant
+-- routes the request when Meta sends @Content-Type: application/json@) but keeps
+-- the body as raw bytes for HMAC verification. Defining a fresh 'Accept'-tagged
+-- type avoids the overlap with Servant's generic
+-- @FromJSON a => MimeUnrender JSON a@ instance.
+data RawJson
+
+instance Accept RawJson where
+  contentTypes _ = NE.fromList ["application" // "json", "application" // "*"]
+
+instance S.MimeRender RawJson RawByteString where
+  mimeRender _ = getRawByteString
+
+instance S.MimeUnrender RawJson RawByteString where
+  mimeUnrender _ = Right . RawByteString
+
+-- | Pure X-Hub-Signature-256 check. Header format is @sha256=<hex>@; anything
+-- else (missing header, missing prefix, malformed/odd-length hex) is False and
+-- never throws (secureEqHex handles undecodable hex).
+verifyMetaSignaturePure :: Text -> Maybe Text -> LBS.ByteString -> Bool
+verifyMetaSignaturePure appSecret mSigHeader raw =
+  case mSigHeader >>= T.stripPrefix "sha256=" of
+    Nothing -> False
+    Just hex ->
+      secureEqHex
+        (hmacSHA256Hex (encodeUtf8 appSecret) (LBS.toStrict raw))
+        (encodeUtf8 hex)
+
+-- | Throwing wrapper for the webhook route. Throws @InvalidRequest@ on mismatch.
+verifyMetaSignature ::
+  (MonadThrow m, Log m) =>
+  Text ->
+  Maybe Text ->
+  RawByteString ->
+  m ()
+verifyMetaSignature appSecret mSigHeader (RawByteString rawBody) =
+  unless (verifyMetaSignaturePure appSecret mSigHeader rawBody) $
+    throwError (InvalidRequest "INVALID_META_SIGNATURE")
+
+-- | GET verification handshake. Given the configured verify token and the
+-- @hub.mode@ / @hub.verify_token@ / @hub.challenge@ query params, echo the
+-- challenge VERBATIM iff mode is "subscribe" and the token matches (constant
+-- time). The caller serves the result as text/plain.
+metaVerifyChallenge :: Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text
+metaVerifyChallenge cfgToken mMode mToken mChallenge =
+  case (mMode, mToken, mChallenge) of
+    (Just "subscribe", Just t, Just c)
+      | constEq (encodeUtf8 t :: BS.ByteString) (encodeUtf8 cfgToken :: BS.ByteString) -> Just c
+    _ -> Nothing
+
+decodeWebhookEnvelope :: RawByteString -> Either String MetaWebhookEnvelope
+decodeWebhookEnvelope (RawByteString raw) = eitherDecode raw
+
+hmacSHA256Hex :: BS.ByteString -> BS.ByteString -> BS.ByteString
+hmacSHA256Hex key msg =
+  let mac = hmac key msg :: HMAC SHA256
+   in convertToBase Base16 (hmacGetDigest mac)
+
+-- | Compare two hex strings in constant time. Base16-decodes both sides then
+-- constEq; malformed/odd-length hex yields False and never throws.
+secureEqHex :: BS.ByteString -> BS.ByteString -> Bool
+secureEqHex a b =
+  case ( convertFromBase Base16 a :: Either String BS.ByteString,
+         convertFromBase Base16 b :: Either String BS.ByteString
+       ) of
+    (Right da, Right db) -> constEq da db
+    _ -> False


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

Adds `Kernel.External.Meta` to mobility-core — a client and type layer for the Meta WhatsApp Cloud API. Covers outbound sends (text, interactive buttons/lists, location request, video) and inbound webhook envelopes (text, interactive replies, location, delivery/read statuses), with Aeson types matching Meta's current field optionality. hpack auto-exposes the 7 modules (`Kernel.External.Meta` + `Meta/{Api,Config,Error,Flow,Types,Webhook}`). Additive only — no existing module changes. Codec tests and JSON fixtures are kept on the `whatsapp-booking` branch to keep this PR code-only.

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables

## Motivation and Context

The existing `Kernel.External.Whatsapp` targets OTP/template BSPs (Karix/Twilio/Tata), not the Meta Cloud API's interactive-message and webhook surface. This adds that as a sibling module so rider-app can host a WhatsApp conversational booking channel, migrated from the TypeScript `ny-connectors` connector (companion nammayatri PR: <NAMMAYATRI_PR_LINK>). Landing it on `main` lets nammayatri track shared-kernel `main` instead of a feature-branch pin, removing recurring `flake.lock` conflicts.

## How did you test it?

Consumed and validated live end-to-end by the rider-app WhatsApp bot against the real Meta platform (message → menu → search → real estimate → confirmed booking). Codec round-trip and JSON fixture tests are maintained on the `whatsapp-booking` branch.

## Checklist

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible — kept on `whatsapp-booking` branch to keep this PR code-only
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable — N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Meta WhatsApp Cloud API integration for sending text, video, button, list, and location-request messages.
  * Added support for receiving and decoding WhatsApp webhook events, including messages, statuses, and errors.
  * Added secure webhook signature verification and subscription challenge handling.
  * Added structured configuration, API responses, and error handling with retry-aware classifications.
  * Added forward-compatible handling for unknown interactive replies and status values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->