### PR TITLE
fix: refunds reference

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Payment/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface.hs
@@ -680,7 +680,9 @@ refundPayment serviceConfig mRoutingId req = case serviceConfig of
           status = maybe REFUND_PENDING (.status) firstRefund,
           amount = Nothing, -- Juspay refund responses do not surface the refunded amount
           errorCode = firstRefund >>= (.errorCode),
-          errorMessage = firstRefund >>= (.errorMessage)
+          errorMessage = firstRefund >>= (.errorMessage),
+          reference = firstRefund >>= (.arn), -- Juspay's arn is its reference number
+          referenceType = Nothing -- Juspay does not tell us which kind
         }
   StripeConfig cfg -> do
     paymentIntentId' <- req.paymentIntentId & fromMaybeM (InternalError "paymentIntentId required for Stripe refund")
@@ -703,7 +705,9 @@ refundPayment serviceConfig mRoutingId req = case serviceConfig of
           status = resp.status,
           amount = Just resp.amount,
           errorCode = resp.errorCode,
-          errorMessage = Nothing
+          errorMessage = Nothing,
+          reference = resp.reference,
+          referenceType = resp.referenceType
         }
   PaytmEDCConfig _ -> throwError $ InternalError "PaytmEDC Refund not supported."
 
@@ -728,6 +732,8 @@ getRefundStatus serviceConfig req = case serviceConfig of
           status = resp.status,
           amount = Just resp.amount,
           errorCode = resp.errorCode,
-          errorMessage = Nothing
+          errorMessage = Nothing,
+          reference = resp.reference,
+          referenceType = resp.referenceType
         }
   PaytmEDCConfig _ -> throwError $ InternalError "PaytmEDC getRefundStatus not supported."

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Stripe.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Stripe.hs
@@ -758,7 +758,7 @@ createRefund config req = do
 
     mkRefundResp :: Stripe.RefundObject -> CreateRefundResp
     mkRefundResp Stripe.RefundObject {..} =
-      CreateRefundResp {status = castRefundStatus status, amount = centsToUsd amount, errorCode = failure_reason, ..}
+      CreateRefundResp {status = castRefundStatus status, amount = centsToUsd amount, errorCode = failure_reason, reference = destination_details >>= (.reference), referenceType = destination_details >>= (.reference_type), ..}
 
 castRefundStatus :: Stripe.RefundStatus -> RefundStatus
 castRefundStatus = \case
@@ -811,5 +811,7 @@ mkGetRefundResp Stripe.RefundObject {..} =
       amount = centsToUsd amount,
       currency = readMaybe . T.unpack $ T.toUpper currency,
       status = castRefundStatus status,
-      errorCode = failure_reason
+      errorCode = failure_reason,
+      reference = destination_details >>= (.reference),
+      referenceType = destination_details >>= (.reference_type)
     }

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
@@ -947,7 +947,9 @@ data CreateRefundResp = CreateRefundResp
   { id :: RefundId,
     status :: RefundStatus,
     amount :: HighPrecMoney,
-    errorCode :: Maybe Text
+    errorCode :: Maybe Text,
+    reference :: Maybe Text,
+    referenceType :: Maybe Text
   }
 
 data GetRefundReq = GetRefundReq
@@ -964,7 +966,9 @@ data GetRefundResp = GetRefundResp
     amount :: HighPrecMoney,
     currency :: Maybe Currency,
     status :: RefundStatus,
-    errorCode :: Maybe Text
+    errorCode :: Maybe Text,
+    reference :: Maybe Text, -- Assigned asynchronously, up to 7 business days after the refund
+    referenceType :: Maybe Text -- acquirer_reference_number | stan | rrn; cards only
   }
   deriving stock (Show)
 
@@ -1045,7 +1049,9 @@ data RefundPaymentResp = RefundPaymentResp
     status :: RefundStatus,
     amount :: Maybe HighPrecMoney,
     errorCode :: Maybe Text,
-    errorMessage :: Maybe Text
+    errorMessage :: Maybe Text,
+    reference :: Maybe Text,
+    referenceType :: Maybe Text
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON, ToSchema)

--- a/lib/mobility-core/src/Kernel/External/Payment/Stripe/Types/Refund.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Stripe/Types/Refund.hs
@@ -4,6 +4,7 @@
 module Kernel.External.Payment.Stripe.Types.Refund where
 
 import Data.Aeson
+import qualified Data.Aeson.Key as AK
 import qualified Data.HashMap.Strict as HM
 import Data.OpenApi (ToSchema (declareNamedSchema), genericDeclareNamedSchema)
 import Kernel.External.Payment.Stripe.Types.Common
@@ -48,6 +49,44 @@ newtype RefundId = RefundId {getRefundId :: Text}
   deriving stock (Generic, Show, Eq)
   deriving newtype (FromJSON, ToJSON, ToSchema, FromHttpApiData, ToHttpApiData)
 
+-- | The reference is nested under the destination payment method, so the key is dynamic:
+--   destination_details.card.reference, .eu_bank_transfer.reference, etc. The sibling `type` names it.
+data RefundDestinationDetails = RefundDestinationDetails
+  { _type :: Text, -- Names the nested key holding the reference; not the nested object's own 'type'
+    reference :: Maybe Text, -- The number the customer can trace with their bank
+    reference_status :: Maybe Text, -- pending | available | unavailable
+    reference_type :: Maybe Text -- e.g. acquirer_reference_number; cards only
+  }
+  deriving stock (Show, Generic)
+
+instance FromJSON RefundDestinationDetails where
+  parseJSON = withObject "RefundDestinationDetails" $ \obj -> do
+    _type <- obj .: "type"
+    obj .:? AK.fromText _type >>= \case
+      Nothing -> pure RefundDestinationDetails {reference = Nothing, reference_status = Nothing, reference_type = Nothing, ..}
+      Just details -> do
+        reference <- details .:? "reference"
+        reference_status <- details .:? "reference_status"
+        reference_type <- details .:? "reference_type"
+        pure RefundDestinationDetails {..}
+
+instance ToJSON RefundDestinationDetails where
+  toJSON RefundDestinationDetails {..} =
+    object
+      [ "type" .= _type,
+        AK.fromText _type
+          .= object
+            ( catMaybes
+                [ ("reference" .=) <$> reference,
+                  ("reference_status" .=) <$> reference_status,
+                  ("reference_type" .=) <$> reference_type
+                ]
+            )
+      ]
+
+instance ToSchema RefundDestinationDetails where
+  declareNamedSchema = genericDeclareNamedSchema S.stripPrefixUnderscoreIfAny
+
 data RefundObject = RefundObject
   { id :: RefundId,
     _object :: Text, -- Value is 'refund'
@@ -56,6 +95,7 @@ data RefundObject = RefundObject
     charge :: Maybe Text, -- ID of the charge that was refunded
     created :: Int, -- Time at which the refund was created
     currency :: Text, -- Currency of the refund
+    destination_details :: Maybe RefundDestinationDetails, -- Where the refund was sent, and its bank-traceable reference
     metadata :: Maybe Metadata, -- Set of key-value pairs attached to the refund
     payment_intent :: Maybe Text, -- ID of the PaymentIntent that was refunded
     reason :: Maybe RefundReason, -- Reason for the refund


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refund records now include acquirer or reconciliation references and their reference types when available.
  * Stripe refund details now capture destination information, including bank-traceable references.
  * Refund status and payment responses consistently surface these references across supported payment providers.

* **Improvements**
  * Enhanced refund tracking and reconciliation with clearer provider-specific reference data.
  * Existing error details continue to be reported where provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->