### PR TITLE
feat: add generic runWithFallbackAndTimeout provider-fallback helper

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Verification/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Interface.hs
@@ -74,6 +74,7 @@ import Kernel.Tools.Metrics.CoreMetrics.Types
 import Kernel.Types.Common
 import Kernel.Types.Error
 import Kernel.Utils.Common
+import Kernel.Utils.Forkable (runWithFallbackAndTimeout)
 
 verifyDL ::
   ( EncFlow m r,
@@ -314,41 +315,57 @@ extractRCImage ::
   ( EncFlow m r,
     CoreMetrics m,
     HasRequestId r,
-    MonadReader r m
+    MonadReader r m,
+    Forkable m
   ) =>
-  VerificationServiceConfig ->
+  ImageExtractionHandler m ->
   ExtractRCImageReq ->
   m ExtractRCImageResp
-extractRCImage serviceConfig req = case serviceConfig of
-  EkatraConfig cfg -> Ekatra.extractRCImage cfg req
-  IdfyConfig cfg -> Idfy.extractRCImage cfg req
-  GovtDataConfig -> throwError $ InternalError "Not Implemented!"
-  FaceVerificationConfig _ -> throwError $ InternalError "Not Implemented!"
-  HyperVergeVerificationConfig _ -> throwError $ InternalError "Not Implemented!"
-  HyperVergeVerificationConfigRCDL _ -> throwError $ InternalError "Not Implemented!"
-  DigiLockerConfig _ -> throwError $ InternalError "Not Implemented!"
-  TtenVerificationConfig _ -> throwError $ InternalError "Not Implemented!"
-  MorthConfig _ -> throwError $ InternalError "Not Implemented!"
+extractRCImage ImageExtractionHandler {..} req = do
+  providers <- getProvidersPriorityList
+  timeoutInSec <- getProviderTimeout
+  when (null providers) $
+    throwError (InternalError "extractRCImage: No image extraction provider configured in the priority list")
+  runWithFallbackAndTimeout "extractRCImage" providers timeoutInSec (isJust . (.extractedRC)) $ \provider -> do
+    serviceConfig <- getProviderConfig provider
+    case serviceConfig of
+      EkatraConfig cfg -> Ekatra.extractRCImage cfg req
+      IdfyConfig cfg -> Idfy.extractRCImage cfg req
+      GovtDataConfig -> throwError $ InternalError "Not Implemented!"
+      FaceVerificationConfig _ -> throwError $ InternalError "Not Implemented!"
+      HyperVergeVerificationConfig _ -> throwError $ InternalError "Not Implemented!"
+      HyperVergeVerificationConfigRCDL _ -> throwError $ InternalError "Not Implemented!"
+      DigiLockerConfig _ -> throwError $ InternalError "Not Implemented!"
+      TtenVerificationConfig _ -> throwError $ InternalError "Not Implemented!"
+      MorthConfig _ -> throwError $ InternalError "Not Implemented!"
 
 extractDLImage ::
   ( EncFlow m r,
     CoreMetrics m,
     HasRequestId r,
-    MonadReader r m
+    MonadReader r m,
+    Forkable m
   ) =>
-  VerificationServiceConfig ->
+  ImageExtractionHandler m ->
   ExtractDLImageReq ->
   m ExtractDLImageResp
-extractDLImage serviceConfig req = case serviceConfig of
-  EkatraConfig cfg -> Ekatra.extractDLImage cfg req
-  IdfyConfig cfg -> Idfy.extractDLImage cfg req
-  GovtDataConfig -> throwError $ InternalError "Not Implemented!"
-  FaceVerificationConfig _ -> throwError $ InternalError "Not Implemented!"
-  HyperVergeVerificationConfig _ -> throwError $ InternalError "Not Implemented!"
-  HyperVergeVerificationConfigRCDL _ -> throwError $ InternalError "Not Implemented!"
-  DigiLockerConfig _ -> throwError $ InternalError "Not Implemented!"
-  TtenVerificationConfig _ -> throwError $ InternalError "Not Implemented!"
-  MorthConfig _ -> throwError $ InternalError "Not Implemented!"
+extractDLImage ImageExtractionHandler {..} req = do
+  providers <- getProvidersPriorityList
+  timeoutInSec <- getProviderTimeout
+  when (null providers) $
+    throwError (InternalError "extractDLImage: No image extraction provider configured in the priority list")
+  runWithFallbackAndTimeout "extractDLImage" providers timeoutInSec (isJust . (.extractedDL)) $ \provider -> do
+    serviceConfig <- getProviderConfig provider
+    case serviceConfig of
+      EkatraConfig cfg -> Ekatra.extractDLImage cfg req
+      IdfyConfig cfg -> Idfy.extractDLImage cfg req
+      GovtDataConfig -> throwError $ InternalError "Not Implemented!"
+      FaceVerificationConfig _ -> throwError $ InternalError "Not Implemented!"
+      HyperVergeVerificationConfig _ -> throwError $ InternalError "Not Implemented!"
+      HyperVergeVerificationConfigRCDL _ -> throwError $ InternalError "Not Implemented!"
+      DigiLockerConfig _ -> throwError $ InternalError "Not Implemented!"
+      TtenVerificationConfig _ -> throwError $ InternalError "Not Implemented!"
+      MorthConfig _ -> throwError $ InternalError "Not Implemented!"
 
 extractPanImage ::
   ( EncFlow m r,

--- a/lib/mobility-core/src/Kernel/External/Verification/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Verification/Interface/Types.hs
@@ -42,6 +42,12 @@ newtype DriverBackgroundVerificationServiceConfig = SafetyPortalConfig SafetyPor
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
+data ImageExtractionHandler m = ImageExtractionHandler
+  { getProvidersPriorityList :: m [VT.VerificationService],
+    getProviderTimeout :: m Int,
+    getProviderConfig :: VT.VerificationService -> m VerificationServiceConfig
+  }
+
 data VerifyDLReq = VerifyDLReq
   { dlNumber :: Text,
     driverId :: Text,

--- a/lib/mobility-core/src/Kernel/Utils/Forkable.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Forkable.hs
@@ -2,7 +2,11 @@ module Kernel.Utils.Forkable where
 
 import qualified EulerHS.Language as L
 import EulerHS.Prelude hiding (length, map)
+import EulerHS.Types (AwaitingError (..), Microseconds (..))
+import Kernel.Types.Error (GenericError (InternalError))
 import Kernel.Types.Forkable
+import Kernel.Utils.Error.Throwing (throwError)
+import Kernel.Utils.Logging (Log, logInfo)
 
 mapConcurrently :: (L.MonadFlow m, Forkable m) => (a -> m b) -> [a] -> m [b]
 mapConcurrently fn ar = do
@@ -14,3 +18,29 @@ mapConcurrentlyTagged :: (L.MonadFlow m, Forkable m) => (a -> m b) -> [(Text, a)
 mapConcurrentlyTagged fn ar = do
   awaitables <- mapM (\(tag, x) -> awaitableFork tag (fn x)) ar
   rights <$> mapM (L.await Nothing) awaitables
+
+-- Runs each provider on a fresh EulerHS fork with a per-call timeout. On
+-- timeout the caller stops waiting and moves on — EulerHS exposes no
+-- cancellation primitive, so the forked flow keeps running in the background
+-- and its result is discarded. Provider actions must be safe to leave running
+-- (typically HTTP calls whose manager has its own responseTimeout).
+runWithFallbackAndTimeout ::
+  (L.MonadFlow m, Forkable m, Log m, MonadThrow m) =>
+  Text ->
+  [a] ->
+  Int ->
+  (b -> Bool) ->
+  (a -> m b) ->
+  m b
+runWithFallbackAndTimeout tag providers timeoutInSec isSuccess action = go providers
+  where
+    go [] =
+      throwError $ InternalError (tag <> ": all configured providers exhausted (timeout/failure)")
+    go (provider : rest) = do
+      awaitable <- awaitableFork tag (action provider)
+      L.await (Just (Microseconds (fromIntegral timeoutInSec * 1000000))) awaitable >>= \case
+        Right result
+          | isSuccess result -> pure result
+          | otherwise -> logInfo (tag <> ": provider returned unsuccessful result; falling back") >> go rest
+        Left AwaitingTimeout -> logInfo (tag <> ": provider timed out after " <> show timeoutInSec <> "s; falling back") >> go rest
+        Left (ForkedFlowError e) -> logInfo (tag <> ": provider failed (" <> e <> "); falling back") >> go rest


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled automatic provider-priority fallback for registration certificate (RC) and driver’s license (DL) image extraction.
  * Added configurable per-provider timeouts and smart success detection to speed up reliable extraction.
* **Bug Fixes**
  * Improved robustness by trying the next provider after timeouts, provider failures, or unsuccessful extraction results.
  * When no verification providers are available, the system now returns a clearer internal error instead of failing ambiguously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->