### PR TITLE
feat: add Clevertap event tracking provider

### DIFF
--- a/lib/mobility-core/mobility-core.cabal
+++ b/lib/mobility-core/mobility-core.cabal
@@ -78,6 +78,10 @@ library
       Kernel.External.ChallanSearch.Types
       Kernel.External.Encryption
       Kernel.External.EventTracking
+      Kernel.External.EventTracking.Clevertap.API
+      Kernel.External.EventTracking.Clevertap.Config
+      Kernel.External.EventTracking.Clevertap.Flow
+      Kernel.External.EventTracking.Clevertap.Types
       Kernel.External.EventTracking.Interface
       Kernel.External.EventTracking.Interface.Types
       Kernel.External.EventTracking.Moengage.API

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Clevertap/API.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Clevertap/API.hs
@@ -1,0 +1,33 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.EventTracking.Clevertap.API
+  ( ClevertapUploadAPI,
+    clevertapUploadAPI,
+  )
+where
+
+import Kernel.External.EventTracking.Clevertap.Types
+import Kernel.Prelude
+import Servant
+
+type ClevertapUploadAPI =
+  "1" :> "upload"
+    :> Header' '[Required, Strict] "X-CleverTap-Account-Id" Text
+    :> Header' '[Required, Strict] "X-CleverTap-Passcode" Text
+    :> ReqBody '[JSON] ClevertapUploadReq
+    :> Post '[JSON] ClevertapUploadResp
+
+clevertapUploadAPI :: Proxy ClevertapUploadAPI
+clevertapUploadAPI = Proxy

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Clevertap/Config.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Clevertap/Config.hs
@@ -1,0 +1,30 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.EventTracking.Clevertap.Config where
+
+import Kernel.External.Encryption
+import Kernel.Prelude
+
+-- | Configuration for the Clevertap server-to-server upload API.
+--
+-- Note the auth model differs from Moengage: Clevertap uses two custom headers
+-- rather than HTTP Basic, and takes no account identifier in the path or query.
+data ClevertapCfg = ClevertapCfg
+  { baseUrl :: BaseUrl,
+    accountId :: Text,
+    passcode :: EncryptedField 'AsEncrypted Text,
+    enabled :: Bool
+  }
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Clevertap/Flow.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Clevertap/Flow.hs
@@ -1,0 +1,86 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.EventTracking.Clevertap.Flow
+  ( pushEvent,
+  )
+where
+
+import qualified Data.Text as T
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import EulerHS.Types (client)
+import Kernel.External.Encryption (decrypt)
+import Kernel.External.EventTracking.Clevertap.API
+import Kernel.External.EventTracking.Clevertap.Config
+import Kernel.External.EventTracking.Clevertap.Types
+import Kernel.External.EventTracking.Interface.Types (EventTrackingReq (..))
+import Kernel.Prelude
+import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
+import Kernel.Types.Common
+import Kernel.Types.Error
+import Kernel.Utils.Common
+
+-- | Push an event to the Clevertap upload API.
+--
+-- The @enabled@ check lives in "Kernel.External.EventTracking.Interface", not
+-- here, so every provider gets it without having to remember it.
+pushEvent ::
+  ( EncFlow m r,
+    CoreMetrics m,
+    MonadFlow m,
+    HasRequestId r,
+    MonadReader r m
+  ) =>
+  ClevertapCfg ->
+  EventTrackingReq ->
+  m ()
+pushEvent cfg req = do
+  passcode <- decrypt cfg.passcode
+  let clevertapClient = client (Proxy :: Proxy ClevertapUploadAPI)
+  resp <-
+    callAPI cfg.baseUrl (clevertapClient cfg.accountId passcode (toClevertapReq req)) "clevertapUpload" clevertapUploadAPI
+      >>= fromEitherM (\err -> InternalError $ "Failed to call Clevertap Upload API: " <> show err)
+  -- Clevertap answers HTTP 200 even when individual events are rejected, so a
+  -- non-empty `unprocessed` is a real failure that would otherwise be silent.
+  case resp.unprocessed of
+    Just failures@(_ : _) ->
+      logError $
+        "Clevertap rejected event " <> req.eventName <> " (status: " <> resp.status <> "): "
+          <> T.intercalate "; " (map describeFailure failures)
+    _ ->
+      logDebug $
+        "Clevertap event " <> req.eventName <> " accepted (status: " <> resp.status <> ", processed: " <> show resp.processed <> ")"
+
+-- | Render a rejected event as @code: message@ for the log line. The record
+-- itself is omitted: it is the payload we just sent and may carry user data.
+describeFailure :: ClevertapUnprocessed -> Text
+describeFailure failure =
+  maybe "unknown" show failure.code <> ": " <> fromMaybe "no error message" failure._error
+
+-- | Map the provider-agnostic request onto Clevertap's wire format.
+toClevertapReq :: EventTrackingReq -> ClevertapUploadReq
+toClevertapReq req =
+  ClevertapUploadReq
+    { d =
+        [ ClevertapEvent
+            { _identity = req.customerId,
+              _type = "event",
+              evtName = req.eventName,
+              evtData = req.attributes,
+              ts = toEpoch <$> req.timestamp
+            }
+        ]
+    }
+  where
+    toEpoch = floor . utcTimeToPOSIXSeconds

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Clevertap/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Clevertap/Types.hs
@@ -1,0 +1,74 @@
+{-
+  Copyright 2022-23, Juspay India Pvt Ltd
+
+  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+
+  as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. This program is
+
+  distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+
+  FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero
+
+  General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+-}
+
+module Kernel.External.EventTracking.Clevertap.Types where
+
+import Data.Aeson (Value)
+import Kernel.Prelude
+import Kernel.Utils.JSON (stripPrefixUnderscoreIfAny)
+
+-- | Clevertap's upload endpoint takes a batch under the key @d@. We currently
+-- send a single event per call; the list shape is the vendor's, not ours.
+newtype ClevertapUploadReq = ClevertapUploadReq
+  { d :: [ClevertapEvent]
+  }
+  deriving (Show, Generic, ToJSON, FromJSON)
+
+data ClevertapEvent = ClevertapEvent
+  { -- | Underscore-prefixed to avoid clashing with 'Kernel.Prelude.identity';
+    -- 'stripPrefixUnderscoreIfAny' restores the wire name @identity@.
+    _identity :: Text,
+    _type :: Text,
+    evtName :: Text,
+    evtData :: Value,
+    -- | Event time as a Unix epoch, per Clevertap's @ts@ field.
+    ts :: Maybe Int
+  }
+  deriving (Show, Generic)
+
+instance ToJSON ClevertapEvent where
+  toJSON = genericToJSON stripPrefixUnderscoreIfAny
+
+instance FromJSON ClevertapEvent where
+  parseJSON = genericParseJSON stripPrefixUnderscoreIfAny
+
+-- | Clevertap reports per-event failures in @unprocessed@ while still
+-- returning HTTP 200, so this response must be inspected rather than ignored.
+--
+-- @status@ is one of @success@, @partial@ or @fail@; we key off @unprocessed@
+-- rather than @status@ so a partial success is not mistaken for a clean one.
+data ClevertapUploadResp = ClevertapUploadResp
+  { status :: Text,
+    processed :: Maybe Int,
+    unprocessed :: Maybe [ClevertapUnprocessed]
+  }
+  deriving (Show, Generic, ToJSON, FromJSON)
+
+-- | A single rejected event. @code@ carries Clevertap's error number, e.g. 527
+-- for a timestamp outside the allowed ingestion window.
+data ClevertapUnprocessed = ClevertapUnprocessed
+  { status :: Text,
+    code :: Maybe Int,
+    -- | Underscore-prefixed to keep clear of 'Prelude.error';
+    -- 'stripPrefixUnderscoreIfAny' restores the wire name @error@.
+    _error :: Maybe Text,
+    record :: Maybe Value
+  }
+  deriving (Show, Generic)
+
+instance ToJSON ClevertapUnprocessed where
+  toJSON = genericToJSON stripPrefixUnderscoreIfAny
+
+instance FromJSON ClevertapUnprocessed where
+  parseJSON = genericParseJSON stripPrefixUnderscoreIfAny

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Interface.hs
@@ -19,15 +19,18 @@ module Kernel.External.EventTracking.Interface
 where
 
 import Kernel.External.Encryption
+import qualified Kernel.External.EventTracking.Clevertap.Flow as ClevertapFlow
 import Kernel.External.EventTracking.Interface.Types as Reexport
 import qualified Kernel.External.EventTracking.Moengage.Flow as MoengageFlow
-import Kernel.External.EventTracking.Moengage.Types
 import Kernel.Prelude
 import Kernel.Tools.Metrics.CoreMetrics (CoreMetrics)
 import Kernel.Types.Common
-import Kernel.Utils.Common (HasRequestId)
+import Kernel.Utils.Common (HasRequestId, logDebug)
 
--- | Push event to event tracking provider - dispatches to appropriate provider
+-- | Push event to event tracking provider - dispatches to appropriate provider.
+--
+-- The per-provider @enabled@ kill switch is enforced here rather than inside
+-- each provider's Flow, so a new provider cannot forget to honour it.
 pushEvent ::
   ( EncFlow m r,
     CoreMetrics m,
@@ -36,7 +39,21 @@ pushEvent ::
     MonadReader r m
   ) =>
   EventTrackingServiceConfig ->
-  MoengageEventReq ->
-  m (Maybe MoengageEventResp)
-pushEvent config req = case config of
-  MoengageConfig moengageCfg -> MoengageFlow.pushEvent moengageCfg req
+  EventTrackingReq ->
+  m ()
+pushEvent config req
+  | not (isEnabled config) =
+    logDebug $ "EventTracking: " <> providerName config <> " is disabled, skipping event " <> req.eventName
+  | otherwise = case config of
+    MoengageConfig moengageCfg -> MoengageFlow.pushEvent moengageCfg req
+    ClevertapConfig clevertapCfg -> ClevertapFlow.pushEvent clevertapCfg req
+
+isEnabled :: EventTrackingServiceConfig -> Bool
+isEnabled = \case
+  MoengageConfig cfg -> cfg.enabled
+  ClevertapConfig cfg -> cfg.enabled
+
+providerName :: EventTrackingServiceConfig -> Text
+providerName = \case
+  MoengageConfig _ -> "Moengage"
+  ClevertapConfig _ -> "Clevertap"

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Interface/Types.hs
@@ -17,16 +17,32 @@
 
 module Kernel.External.EventTracking.Interface.Types
   ( EventTrackingServiceConfig (..),
+    EventTrackingReq (..),
   )
 where
 
 import Data.Aeson
 import Deriving.Aeson
+import qualified Kernel.External.EventTracking.Clevertap.Config as ClevertapConfig
 import qualified Kernel.External.EventTracking.Moengage.Config as MoengageConfig
 import Kernel.Prelude
 
 -- | Configuration sum type for all event tracking providers
 data EventTrackingServiceConfig
   = MoengageConfig MoengageConfig.MoengageCfg
+  | ClevertapConfig ClevertapConfig.ClevertapCfg
   deriving (Show, Eq, Generic)
   deriving (FromJSON, ToJSON) via CustomJSON '[SumTaggedObject "tag" "content"] EventTrackingServiceConfig
+
+-- | Provider-agnostic event payload.
+--
+-- Callers build this; each provider's Flow maps it to that vendor's wire type.
+-- Keeping it neutral means adding a provider does not touch calling services.
+data EventTrackingReq = EventTrackingReq
+  { customerId :: Text,
+    eventName :: Text,
+    attributes :: Value,
+    -- | Event time, where the provider supports it. Moengage ignores this.
+    timestamp :: Maybe UTCTime
+  }
+  deriving (Show, Generic, ToJSON, FromJSON)

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Moengage/Flow.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Moengage/Flow.hs
@@ -22,6 +22,7 @@ import qualified "base64-bytestring" Data.ByteString.Base64 as B64
 import qualified Data.Text.Encoding as TE
 import EulerHS.Types (client)
 import Kernel.External.Encryption (decrypt)
+import Kernel.External.EventTracking.Interface.Types (EventTrackingReq (..))
 import Kernel.External.EventTracking.Moengage.API
 import Kernel.External.EventTracking.Moengage.Config
 import Kernel.External.EventTracking.Moengage.Types
@@ -31,7 +32,10 @@ import Kernel.Types.Common
 import Kernel.Types.Error
 import Kernel.Utils.Common
 
--- | Push an event to Moengage S2S API
+-- | Push an event to Moengage S2S API.
+--
+-- The @enabled@ check lives in "Kernel.External.EventTracking.Interface", not
+-- here, so every provider gets it without having to remember it.
 pushEvent ::
   ( EncFlow m r,
     CoreMetrics m,
@@ -40,19 +44,30 @@ pushEvent ::
     MonadReader r m
   ) =>
   MoengageCfg ->
-  MoengageEventReq ->
-  m (Maybe MoengageEventResp)
+  EventTrackingReq ->
+  m ()
 pushEvent cfg req = do
-  if not cfg.enabled
-    then pure Nothing
-    else do
-      apiSecret <- decrypt cfg.apiSecret
-      let authToken = buildBasicAuth cfg.appId apiSecret
-          moengageClient = client (Proxy :: Proxy MoengageEventAPI)
-      resp <-
-        callAPI cfg.baseUrl (moengageClient cfg.appId cfg.appId (Just authToken) req) "moengageEvent" moengageEventAPI
-          >>= fromEitherM (const $ InternalError "Failed to call Moengage Event API")
-      pure (Just resp)
+  apiSecret <- decrypt cfg.apiSecret
+  let authToken = buildBasicAuth cfg.appId apiSecret
+      moengageClient = client (Proxy :: Proxy MoengageEventAPI)
+  resp <-
+    callAPI cfg.baseUrl (moengageClient cfg.appId cfg.appId (Just authToken) (toMoengageReq req)) "moengageEvent" moengageEventAPI
+      >>= fromEitherM (\err -> InternalError $ "Failed to call Moengage Event API: " <> show err)
+  logDebug $ "Moengage event " <> req.eventName <> " accepted with status: " <> resp.status
+
+-- | Map the provider-agnostic request onto Moengage's wire format.
+toMoengageReq :: EventTrackingReq -> MoengageEventReq
+toMoengageReq req =
+  MoengageEventReq
+    { _type = "event",
+      customer_id = req.customerId,
+      actions =
+        [ MoengageAction
+            { action = req.eventName,
+              attributes = req.attributes
+            }
+        ]
+    }
 
 buildBasicAuth :: Text -> Text -> Text
 buildBasicAuth appId apiSecret =

--- a/lib/mobility-core/src/Kernel/External/EventTracking/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Types.hs
@@ -29,11 +29,12 @@ import Kernel.Storage.Esqueleto (derivePersistField)
 -- | Enum of event tracking service providers
 data EventTrackingService
   = Moengage
+  | Clevertap
   deriving (Show, Read, Eq, Ord, Generic, ToJSON, FromJSON)
 
 -- | List of all available event tracking services
 availableEventTrackingServices :: [EventTrackingService]
-availableEventTrackingServices = [Moengage]
+availableEventTrackingServices = [Moengage, Clevertap]
 
 instance (HasSqlValueSyntax be String) => HasSqlValueSyntax be EventTrackingService where
   sqlValueSyntax = autoSqlValueSyntax


### PR DESCRIPTION
## What

Adds **Clevertap** as a second event-tracking provider alongside Moengage, and neutralises the `EventTracking` interface so callers no longer construct a vendor's wire format.

## Why

`Interface.pushEvent` previously took `MoengageEventReq` and returned `Maybe MoengageEventResp`, so Moengage's payload shape leaked all the way up to rider-app. Reusing that type for Clevertap was not viable — `MoengageEventReq`'s `ToJSON` *is* the Moengage wire format, and Clevertap needs fields Moengage lacks (`ts`, `identity`). Adding them there would have leaked foreign fields into Moengage's request body.

## Changes

**Interface**
- New provider-agnostic `EventTrackingReq { customerId, eventName, attributes, timestamp }`. Each provider's Flow maps it to its own wire type, so adding a provider no longer touches calling services.
- `pushEvent` returns `m ()` instead of `Maybe MoengageEventResp`. The only caller discarded the response, so there is no neutral response type to reconcile between vendors.
- The per-provider `enabled` kill switch moves from `Moengage/Flow` into `Interface.pushEvent`, so a new provider cannot forget to honour it.

**Clevertap client**
- `POST /1/upload`, authenticated with `X-CleverTap-Account-Id` + `X-CleverTap-Passcode` headers rather than Basic auth.
- Clevertap returns **HTTP 200 even when individual events are rejected**, listing them under `unprocessed`. That is inspected and logged with the vendor's error code. The rejected record itself is deliberately omitted from logs — it is the payload we sent and carries user data.
- Base URL is region-specific (`in1`, `sg1`, `us1`, `aps3`, `mec1`, or bare `api.clevertap.com` for EU) and configured per merchant.

**Drive-by fix**
- `Moengage/Flow` discarded the underlying error on API failure (`const $ InternalError "..."`), which made auth failures surface as an opaque message. It now includes the real cause.

## Verification

- `cabal build mobility-core` compiles and links (633 modules).
- The Clevertap payload this produces was sent to the live API and accepted, with the event appearing on the dashboard.

## Note for reviewers

The design planned this as two PRs (neutralise, then add Clevertap). They are combined here because the interface files carry both changes and splitting them would produce an intermediate commit that does not build. Commit message documents both phases.

Consumer changes live in a companion nammayatri PR, which **must land after this merges and `flake.lock` is bumped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Clevertap as an event-tracking provider, including event upload support to the Clevertap S2S API.
  * Added Clevertap configuration for credentials, endpoint, and enablement.
  * Supports batching with event timestamp and custom attributes.
* **Improvements**
  * Event dispatch now supports Moengage and Clevertap with an interface-level enable/disable “kill switch”.
  * Improved logging and error handling for accepted and rejected events; Moengage submission behavior was aligned for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->