### PR TITLE
fix: treat Clevertap event rejections as failures, not successes

### DIFF
--- a/lib/mobility-core/src/Kernel/External/EventTracking/Clevertap/Flow.hs
+++ b/lib/mobility-core/src/Kernel/External/EventTracking/Clevertap/Flow.hs
@@ -53,9 +53,13 @@ pushEvent cfg req = do
       >>= fromEitherM (\err -> InternalError $ "Failed to call Clevertap Upload API: " <> show err)
   -- Clevertap answers HTTP 200 even when individual events are rejected, so a
   -- non-empty `unprocessed` is a real failure that would otherwise be silent.
+  --
+  -- We send one event per call, so any entry here means this event was not
+  -- delivered. Throw rather than log-and-return: returning success would make
+  -- the caller report the event as sent, which is simply untrue.
   case resp.unprocessed of
     Just failures@(_ : _) ->
-      logError $
+      throwError . InternalError $
         "Clevertap rejected event " <> req.eventName <> " (status: " <> resp.status <> "): "
           <> T.intercalate "; " (map describeFailure failures)
     _ ->


### PR DESCRIPTION
## Problem

Clevertap returns **HTTP 200 even when it rejects an event**, reporting the rejection under `unprocessed`. We logged that at error level but still **returned successfully**, so the caller went on to log the event as *sent*.

A single rejected event therefore produced two contradictory log lines:

```
ERROR>  Clevertap rejected event driver_assigned (status: fail): 528: Discarded event ...
DEBUG>  EventTracking event driver_assigned (Clevertap) sent          <-- false
```

Anything counting deliveries by grepping `") sent"` would have over-counted, and during an incident the pair is actively confusing.

## Fix

Throw instead of log-and-return. We send **one event per call**, so any entry in `unprocessed` means *this* event was not delivered — "success" is never the right reading.

This routes vendor-level rejections down the **same path API failures already take** for both providers (`fromEitherM ... InternalError`), so the outcome is now one accurate line:

```
ERROR>  EventTracking event driver_assigned (Clevertap) failed: InternalError
        "Clevertap rejected event driver_assigned (status: fail): 528: Discarded event ..."
```

## Observed against the live API

A `driver_assigned` event that is marked **discarded** in the Clevertap dashboard returns HTTP 200 with error **528** (`Trying to raise a discarded event`). Before this change it was reported as sent; four sibling events in the same run were genuinely accepted, so the integration itself is working.

## Safety — no caller change needed, no flow can break

- `pushEvent`'s signature is unchanged (`m ()`), so consumers need no update. nammayatri picks this up whenever its flake is next bumped; there is no urgency to bump.
- rider-app already wraps the call in `try @_ @SomeException`, and every call site sits inside a `fork "event_tracking: ..."`. The throw is caught inside the fork, off the request path — search, booking, driver-assignment and ride-completion flows are unaffected.
- Behaviourally symmetric with Moengage, which already throws on API failure.

## Known remaining gap (not addressed here)

Moengage's response `status` is logged but never checked, so an HTTP 200 with a non-success status would still be reported as accepted — the mirror image of the hole this PR closes for Clevertap. Left alone since there is no evidence Moengage behaves that way.

## Verification

`cabal build mobility-core` on top of latest `main` — compiles and links clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)