### PR TITLE
fix : cap Xyne attachment filename length to avoid object-key overflow

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Ticket/Interface/XyneSpaces.hs
+++ b/lib/mobility-core/src/Kernel/External/Ticket/Interface/XyneSpaces.hs
@@ -398,12 +398,24 @@ detectMimeAndExt bs ct
       "video/webm" -> "webm"
       _ -> "bin"
 
+-- | Xyne rejects object names over 1024 characters. @data:@ URIs have no
+-- path to derive a name from — the naive fallback would otherwise slice a
+-- chunk out of the raw base64 payload (or an embedded conversation string)
+-- and use that as the "filename", which sporadically overshoots the limit.
+-- We also hard-cap the result so any other pathological input can't do the
+-- same; 'T.takeEnd' keeps the extension when one is present, since it sits
+-- at the end of the name.
+maxDerivedFilenameLen :: Int
+maxDerivedFilenameLen = 150
+
 deriveFilename :: Text -> Text -> Text
 deriveFilename url ext =
-  let base = case fromQueryFilePath url of
-        Just fp -> lastPathSegment fp
-        Nothing -> lastPathSegment (T.takeWhile (/= '?') url)
-      cleaned = if T.null base then "attachment" else base
+  let base
+        | "data:" `T.isPrefixOf` url = "attachment"
+        | otherwise = case fromQueryFilePath url of
+          Just fp -> lastPathSegment fp
+          Nothing -> lastPathSegment (T.takeWhile (/= '?') url)
+      cleaned = T.takeEnd maxDerivedFilenameLen (if T.null base then "attachment" else base)
       hasExt = T.isInfixOf "." cleaned
    in if hasExt then cleaned else cleaned <> "." <> ext
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
In deriveFilename:

- data: URIs now always use a fixed "attachment" base instead of being sliced.
- The derived base name is hard-capped at 150 characters (T.takeEnd, which preserves a trailing extension) as a general safety net for any other pathological input.


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented generated filenames from becoming excessively long.
  * Improved handling of filenames derived from data URLs while preserving file extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->