### PR TITLE
fix: reclassify Acko API 4xx rejection from E500 to InvalidRequest

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Insurance/Acko/Flow.hs
+++ b/lib/mobility-core/src/Kernel/External/Insurance/Acko/Flow.hs
@@ -7,7 +7,9 @@ import Kernel.Prelude
 import qualified Kernel.Tools.Metrics.CoreMetrics as Metrics
 import Kernel.Types.Error
 import Kernel.Utils.Common
+import qualified Network.HTTP.Types as HTTP
 import Servant hiding (throwError)
+import Servant.Client (ClientError (..), ResponseF (responseStatusCode))
 
 type CreateInsuranceAPI =
   "product"
@@ -27,4 +29,11 @@ createInsurance url authHeader request = do
 callAckoAPI :: (MonadFlow m, HasRequestId r, MonadReader r m) => CallAPI' m r api res res
 callAckoAPI url eulerClient description proxy = do
   callAPI url eulerClient description proxy
-    >>= fromEitherM (\err -> InternalError $ "Failed to call " <> description <> " API: " <> show err)
+    >>= fromEitherM
+      ( \err -> case err of
+          FailureResponse _ resp
+            | let code = HTTP.statusCode $ responseStatusCode resp,
+              code >= 400 && code < 500 ->
+              InvalidRequest $ "Failed to call " <> description <> " API (downstream 4xx rejection): " <> show err
+          _ -> InternalError $ "Failed to call " <> description <> " API: " <> show err
+      )


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->

Reworked `callAckoAPI` in `Kernel.External.Insurance.Acko.Flow` to classify Servant `ClientError`s correctly:

- `FailureResponse` with a **4xx** status from Acko is now rethrown as `InvalidRequest` (`E400`) while preserving Acko's rejection details in the error message.
- All other errors (5xx responses, timeouts, connection failures, and decode errors) continue to be classified as `InternalError` (`E500`).

### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

The "Fork create insurance" background thread was terminating whenever Acko rejected a policy request with an HTTP 400 response (for example, error code `IVERR_015`). These downstream client-side rejections were being reported as `E500 INTERNAL_ERROR`, resulting in approximately **400 false-positive 5xx errors per day** in the Grafana dashboard.

Since a downstream 4xx rejection is not an internal server failure, this change ensures it is correctly classified as `E400 InvalidRequest`, improving error reporting and monitoring accuracy while retaining the original rejection details from Acko.

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

- Successfully compiled with `cabal build mobility-core` (all 622 modules compiled and linked successfully).
- Manually verified that downstream 4xx responses from Acko are mapped to `E400 InvalidRequest`, while non-4xx failures continue to be reported as `E500 InternalError`.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for insurance service requests.
  * Downstream 4xx responses are now reported as invalid requests, while other failures continue to be handled as internal errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->