### PR TITLE
fix: make partial (pinned) secondary keys safe on the read path

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -387,16 +387,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1784709631,
-        "narHash": "sha256-AmU6GtFiOtN0V4AtGjepWZ7hrV0oW8K4iHgYjtuItcs=",
+        "lastModified": 1784817230,
+        "narHash": "sha256-eoJjky5AQ7AVDWaN+bW0RcyO57B1SBGULPoOzQn55cM=",
         "owner": "nammayatri",
         "repo": "euler-hs",
-        "rev": "512b2f66445c591e38d08acced512237fd881dfc",
+        "rev": "42ab08abf03ba8b7e9298b84bd79146a6a525fb8",
         "type": "github"
       },
       "original": {
         "owner": "nammayatri",
         "repo": "euler-hs",
+        "rev": "42ab08abf03ba8b7e9298b84bd79146a6a525fb8",
         "type": "github"
       }
     },
@@ -858,11 +859,11 @@
     "hedis": {
       "flake": false,
       "locked": {
-        "lastModified": 1784659501,
-        "narHash": "sha256-ovlZQ5Pe/7QVYSHAxaN3iLIq13bWXbwTWlMOFqWF7rs=",
+        "lastModified": 1740460297,
+        "narHash": "sha256-4FjUqrP+63Te39UM9PctBS8cuJUiJYkZ3zIJ2IPeTA8=",
         "owner": "nammayatri",
         "repo": "hedis",
-        "rev": "7c8a33b2f69e33e428f983a0b7d68ef9d7ecef86",
+        "rev": "089d22be67103f613bd1eecbac8c2e6d6d0576c6",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -387,17 +387,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1784817230,
-        "narHash": "sha256-eoJjky5AQ7AVDWaN+bW0RcyO57B1SBGULPoOzQn55cM=",
+        "lastModified": 1785155093,
+        "narHash": "sha256-NiUhGV6Y/nyQu2HT13LLA2Zdy6u92P4A9vd8p9NSmvU=",
         "owner": "nammayatri",
         "repo": "euler-hs",
-        "rev": "42ab08abf03ba8b7e9298b84bd79146a6a525fb8",
+        "rev": "4badf9391c3bf9805bb8b9177c0da6ee49784d58",
         "type": "github"
       },
       "original": {
         "owner": "nammayatri",
         "repo": "euler-hs",
-        "rev": "42ab08abf03ba8b7e9298b84bd79146a6a525fb8",
         "type": "github"
       }
     },
@@ -859,11 +858,11 @@
     "hedis": {
       "flake": false,
       "locked": {
-        "lastModified": 1740460297,
-        "narHash": "sha256-4FjUqrP+63Te39UM9PctBS8cuJUiJYkZ3zIJ2IPeTA8=",
+        "lastModified": 1784659501,
+        "narHash": "sha256-ovlZQ5Pe/7QVYSHAxaN3iLIq13bWXbwTWlMOFqWF7rs=",
         "owner": "nammayatri",
         "repo": "hedis",
-        "rev": "089d22be67103f613bd1eecbac8c2e6d6d0576c6",
+        "rev": "7c8a33b2f69e33e428f983a0b7d68ef9d7ecef86",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     prometheus-haskell.inputs.haskell-flake.follows = "common/haskell-flake";
 
     euler-hs = {
-      url = "github:nammayatri/euler-hs";
+      url = "github:nammayatri/euler-hs/42ab08abf03ba8b7e9298b84bd79146a6a525fb8";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.haskell-flake.follows = "haskell-flake";
     };

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     prometheus-haskell.inputs.haskell-flake.follows = "common/haskell-flake";
 
     euler-hs = {
-      url = "github:nammayatri/euler-hs/42ab08abf03ba8b7e9298b84bd79146a6a525fb8";
+      url = "github:nammayatri/euler-hs";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.haskell-flake.follows = "haskell-flake";
     };

--- a/lib/mobility-core/src/Kernel/Beam/Lib/UtilsTH.hs
+++ b/lib/mobility-core/src/Kernel/Beam/Lib/UtilsTH.hs
@@ -136,14 +136,20 @@ kvConnectorInstancesD name pKeyN sKeySpecs = do
       sKeyPairs = map (\k -> TupE [Just $ LitE $ StringL $ sortAndGetKey (fst k), Just $ ConE 'False]) sKeys
       -- pinnedKeyMap entries: single-field pinned keys only, and only when the field has no plain
       -- skey spec as well (a plain spec keeps the set complete for every value, so the field may
-      -- keep behaving as a regular key and must not be restricted by the pin).
+      -- keep behaving as a regular key and must not be restricted by the pin). Values are merged
+      -- per field across separate SKeyPartial specs - HM.fromList is last-wins, so unmerged
+      -- duplicates would silently drop the earlier spec's values from read-path eligibility.
       plainKeyNames = map (sortAndGetKey . fst) (filter (null . snd) sKeys)
-      pinnedPairs = mapMaybe mkPinnedPair sKeys
-      mkPinnedPair (cols, pins) = case (map (splitColon . nameBase) cols, pins) of
-        ([fieldName], _ : _)
-          | fieldName `notElem` plainKeyNames ->
-            Just $ TupE [Just $ AppE (VarE 'T.pack) (LitE $ StringL fieldName), Just $ ListE (map (AppE (VarE 'T.pack) . LitE . StringL . snd) pins)]
+      pinnedPairs = map mkPinnedPairE (foldr mergePinned [] (mapMaybe pinnedFieldOf sKeys))
+      pinnedFieldOf (cols, pins) = case (map (splitColon . nameBase) cols, pins) of
+        ([fieldName], _ : _) | fieldName `notElem` plainKeyNames -> Just (fieldName, map snd pins)
         _ -> Nothing
+      mergePinned (f, vs) acc =
+        if any ((== f) . fst) acc
+          then map (\(g, ws) -> if g == f then (g, vs <> filter (`notElem` vs) ws) else (g, ws)) acc
+          else (f, vs) : acc
+      mkPinnedPairE (fieldName, vals) =
+        TupE [Just $ AppE (VarE 'T.pack) (LitE $ StringL fieldName), Just $ ListE (map (AppE (VarE 'T.pack) . LitE . StringL) vals)]
   let tableNameD = FunD 'KV.tableName [Clause [] (NormalB (LitE (StringL $ init $ camel (nameBase name)))) []]
       keyMapD = FunD 'KV.keyMap [Clause [] (NormalB (AppE (VarE 'HM.fromList) (ListE (pKeyPair : sKeyPairs)))) []]
       pinnedKeyMapD = FunD 'KV.pinnedKeyMap [Clause [] (NormalB (AppE (VarE 'HM.fromList) (ListE pinnedPairs))) []]

--- a/lib/mobility-core/src/Kernel/Beam/Lib/UtilsTH.hs
+++ b/lib/mobility-core/src/Kernel/Beam/Lib/UtilsTH.hs
@@ -58,13 +58,29 @@ emptyTextHashMap = HMI.empty
 emptyValueHashMap :: M.Map Text (A.Value -> A.Value)
 emptyValueHashMap = M.empty
 
--- | A partial secondary index. The key is written only for rows where the pinned fields equal the
---   given values (like Postgres @CREATE INDEX ... WHERE col = 'value'@). The pinned fields double as
---   the key columns, so nothing in the KV layer needs to change - a row just carries the key when it
---   matches.
+-- | A partial secondary index. The key is written only for rows where the pinned field equals one
+--   of the given values (like Postgres @CREATE INDEX ... WHERE col IN (...)@). Listing the same
+--   field with several values pins it to any of them (one set per value).
 --
---   e.g. @SKeyPartial [('status, "ACTIVE")]@ indexes status only for ACTIVE rows (one set, status_ACTIVE).
+--   The pinned field is also published via 'KV.pinnedKeyMap', which the euler-hs read path uses to
+--   treat it as a FALLBACK key only: it is consulted only when the where clause has no regular
+--   (non-pinned) key and the queried value is pinned, and it never participates in key-set
+--   intersections. A pinned set is empty for every non-pinned value, so using it like a regular
+--   key erased valid results of other keys (driver dues incident, 2026-07).
+--
+--   e.g. @SKeyPartial [('status, "ACTIVE")]@ maintains the set only for ACTIVE rows (status_ACTIVE).
 data SKeyPartial = SKeyPartial [(Name, String)]
+
+-- | Collapse a pin list to one entry per field: @[('status, "A"), ('status, "B")]@ becomes
+--   @[('status, ["A", "B"])]@ (field pinned to any of the values).
+groupPins :: [(Name, String)] -> [(Name, [String])]
+groupPins = foldr insertPin []
+  where
+    insertPin (f, v) acc =
+      if any ((== fieldStr f) . fieldStr . fst) acc
+        then map (\(g, vs) -> if fieldStr g == fieldStr f then (g, v : vs) else (g, vs)) acc
+        else (f, [v]) : acc
+    fieldStr = splitColon . nameBase
 
 -- | Default for almost every table. Output is identical to before.
 enableKVPG :: Name -> [Name] -> [[Name]] -> Q [Dec]
@@ -77,8 +93,13 @@ enableKVPG name pKeyN sKeysN = kvpgDecs name pKeyN (map (\cols -> (cols, [])) sK
 -- >   [['transactionId]]                    -- plain
 -- >   [SKeyPartial [('status, "ACTIVE")]]   -- partial: status indexed only when ACTIVE
 enableKVPGWithPartialIndex :: Name -> [Name] -> [[Name]] -> [SKeyPartial] -> Q [Dec]
-enableKVPGWithPartialIndex name pKeyN plainSKeys partialSKeys =
-  kvpgDecs name pKeyN (map (\cols -> (cols, [])) plainSKeys ++ map (\(SKeyPartial pins) -> (map fst pins, pins)) partialSKeys)
+enableKVPGWithPartialIndex name pKeyN plainSKeys partialSKeys = do
+  -- A pin spanning two different fields would put a composite key in keyMap with no pin metadata
+  -- (pinnedKeyMap is single-field), recreating the empty-set intersection bug. Reject at compile time.
+  forM_ partialSKeys $ \(SKeyPartial pins) ->
+    when (P.length (groupPins pins) /= 1) $
+      fail $ "SKeyPartial on " <> nameBase name <> " must pin exactly one field (several values for that field are allowed); got fields: " <> show (map (splitColon . nameBase . fst) pins)
+  kvpgDecs name pKeyN (map (\cols -> (cols, [])) plainSKeys ++ map (\(SKeyPartial pins) -> (map fst (groupPins pins), pins)) partialSKeys)
 
 -- | Shared by both entry points. A secondary key is @(cols, pins)@: empty pins = plain, non-empty = partial.
 kvpgDecs :: Name -> [Name] -> [([Name], [(Name, String)])] -> Q [Dec]
@@ -113,12 +134,23 @@ kvConnectorInstancesD name pKeyN sKeySpecs = do
       sKeys = filter (\k -> pKey /= sortAndGetKey (fst k)) sKeySpecs
       pKeyPair = TupE [Just $ LitE $ StringL pKey, Just $ ConE 'True]
       sKeyPairs = map (\k -> TupE [Just $ LitE $ StringL $ sortAndGetKey (fst k), Just $ ConE 'False]) sKeys
+      -- pinnedKeyMap entries: single-field pinned keys only, and only when the field has no plain
+      -- skey spec as well (a plain spec keeps the set complete for every value, so the field may
+      -- keep behaving as a regular key and must not be restricted by the pin).
+      plainKeyNames = map (sortAndGetKey . fst) (filter (null . snd) sKeys)
+      pinnedPairs = mapMaybe mkPinnedPair sKeys
+      mkPinnedPair (cols, pins) = case (map (splitColon . nameBase) cols, pins) of
+        ([fieldName], _ : _)
+          | fieldName `notElem` plainKeyNames ->
+            Just $ TupE [Just $ AppE (VarE 'T.pack) (LitE $ StringL fieldName), Just $ ListE (map (AppE (VarE 'T.pack) . LitE . StringL . snd) pins)]
+        _ -> Nothing
   let tableNameD = FunD 'KV.tableName [Clause [] (NormalB (LitE (StringL $ init $ camel (nameBase name)))) []]
       keyMapD = FunD 'KV.keyMap [Clause [] (NormalB (AppE (VarE 'HM.fromList) (ListE (pKeyPair : sKeyPairs)))) []]
+      pinnedKeyMapD = FunD 'KV.pinnedKeyMap [Clause [] (NormalB (AppE (VarE 'HM.fromList) (ListE pinnedPairs))) []]
       primaryKeyD = FunD 'KV.primaryKey [Clause [] (NormalB getPrimaryKeyE) []]
       secondaryKeysD = FunD 'KV.secondaryKeys [Clause [] (NormalB getSecondaryKeysE) []]
   mkSQLObjectD <- genMkSQLObjectD name
-  return [InstanceD Nothing [] (AppT (ConT ''KV.KVConnector) (AppT (ConT name) (ConT $ mkName "Identity"))) [tableNameD, keyMapD, primaryKeyD, secondaryKeysD, mkSQLObjectD]]
+  return [InstanceD Nothing [] (AppT (ConT ''KV.KVConnector) (AppT (ConT name) (ConT $ mkName "Identity"))) ([tableNameD, keyMapD] <> [pinnedKeyMapD | not (null pinnedPairs)] <> [primaryKeyD, secondaryKeysD, mkSQLObjectD])]
   where
     getPrimaryKeyE =
       let obj = mkName "obj"
@@ -136,11 +168,11 @@ kvConnectorInstancesD name pKeyN sKeySpecs = do
     perSpecListE obj spec = case snd spec of
       [] -> ListE [skeyExprE obj (fst spec)]
       pins -> CondE (gateE obj pins) (ListE [skeyExprE obj (fst spec)]) (ListE [])
-    -- Conjunction of @utilTransform (field obj) == T.pack "constant"@ over all pinned fields.
+    -- Per pinned field: @utilTransform (field obj) `elem` [pinned values]@, AND'ed across fields.
     gateE obj pins =
       AppE (VarE 'and) $
         ListE $
-          map (\(f, c) -> AppE (AppE (VarE '(==)) (getRecFieldE f obj)) (AppE (VarE 'T.pack) (LitE $ StringL c))) pins
+          map (\(f, cs) -> AppE (AppE (VarE 'elem) (getRecFieldE f obj)) (ListE $ map (AppE (VarE 'T.pack) . LitE . StringL) cs)) (groupPins pins)
     skeyExprE obj cols =
       AppE (ConE 'KV.SKey) (ListE $ map (\n -> TupE [Just $ keyNameTextE n, Just $ getRecFieldE n obj]) cols)
     getRecFieldE f obj =

--- a/lib/mobility-core/test/src/PartialIndexTests.hs
+++ b/lib/mobility-core/test/src/PartialIndexTests.hs
@@ -4,14 +4,22 @@
 
 -- | Tests for partial (pinned) secondary keys via 'enableKVPGWithPartialIndex'.
 --
---   The table has a normal secondary key on driverId and a partial one on status pinned to "ACTIVE".
---   We check that secondaryKeys only emits the pinned key when status is ACTIVE - that is what the KV
---   layer uses to decide index membership on create/find/update.
+--   Write side: 'secondaryKeys' emits the pinned key only when the row's field equals one of its
+--   pinned values - that decides redis set membership on create/update.
+--
+--   Read side: 'pinnedKeyMap' publishes the pins, and 'validKeyMapForClause' (euler-hs) restricts
+--   a where-clause combination to the keys it may trust. A pinned set is empty for every
+--   non-pinned value WITHOUT meaning "no rows", so a pinned key must never intersect with other
+--   keys: it is usable only as the sole key in the clause, and only for a pinned value.
+--   (Regression test for the driver dues incident, 2026-07: driverId results were intersected
+--   with the always-empty serviceName/feeType sets and every dues query lost its rows.)
 module PartialIndexTests (partialIndexTests) where
 
 import qualified Data.HashMap.Strict as HM
+import Data.List ((\\))
 import qualified Database.Beam as B
-import EulerHS.KVConnector.Types (KVConnector (keyMap, secondaryKeys), SecondaryKey (..))
+import EulerHS.KVConnector.Types (KVConnector (keyMap, pinnedKeyMap, secondaryKeys), SecondaryKey (..))
+import EulerHS.KVConnector.Utils (validKeyMapForClause)
 import EulerHS.Prelude hiding (id)
 import Kernel.Beam.Lib.UtilsTH
 import Test.Tasty
@@ -39,23 +47,268 @@ $( enableKVPGWithPartialIndex
      [SKeyPartial [('status, "ACTIVE")]] -- partial: status indexed only when ACTIVE
  )
 
+-- | The same field pinned to two values: 'groupPins' must collapse them to ONE key that is
+--   written when the row's value is either of them (OR, not an unsatisfiable AND).
+data MultiPinTestT f = MultiPinTestT
+  { mpId :: B.C f Text,
+    mpStatus :: B.C f Text
+  }
+  deriving (Generic, B.Beamable)
+
+instance B.Table MultiPinTestT where
+  data PrimaryKey MultiPinTestT f
+    = MpId (B.C f Text)
+    deriving (Generic, B.Beamable)
+  primaryKey = MpId . mpId
+
+type MultiPinTest = MultiPinTestT Identity
+
+$( enableKVPGWithPartialIndex
+     ''MultiPinTestT
+     ['mpId]
+     []
+     [SKeyPartial [('mpStatus, "NEW"), ('mpStatus, "PENDING")]]
+ )
+
+-- | A field with BOTH a plain skey and a pin: the plain spec keeps the set complete for every
+--   value, so the field stays a full regular key - the pin must not restrict reads
+--   (Invoice.invoiceStatus / Notification.status shape).
+data PlainPrecTestT f = PlainPrecTestT
+  { ppId :: B.C f Text,
+    ppStatus :: B.C f Text
+  }
+  deriving (Generic, B.Beamable)
+
+instance B.Table PlainPrecTestT where
+  data PrimaryKey PlainPrecTestT f
+    = PpId (B.C f Text)
+    deriving (Generic, B.Beamable)
+  primaryKey = PpId . ppId
+
+type PlainPrecTest = PlainPrecTestT Identity
+
+$( enableKVPGWithPartialIndex
+     ''PlainPrecTestT
+     ['ppId]
+     [['ppStatus]]
+     [SKeyPartial [('ppStatus, "ACTIVE")]]
+ )
+
+-- | The same field pinned via two SEPARATE SKeyPartial specs: values must merge in pinnedKeyMap
+--   (HM.fromList is last-wins - unmerged duplicates would drop the first spec's values from
+--   read-path eligibility while the write side still maintains both sets).
+data SplitPinTestT f = SplitPinTestT
+  { spId :: B.C f Text,
+    spStatus :: B.C f Text
+  }
+  deriving (Generic, B.Beamable)
+
+instance B.Table SplitPinTestT where
+  data PrimaryKey SplitPinTestT f
+    = SpId (B.C f Text)
+    deriving (Generic, B.Beamable)
+  primaryKey = SpId . spId
+
+type SplitPinTest = SplitPinTestT Identity
+
+$( enableKVPGWithPartialIndex
+     ''SplitPinTestT
+     ['spId]
+     []
+     [SKeyPartial [('spStatus, "ACTIVE")], SKeyPartial [('spStatus, "INACTIVE")]]
+ )
+
+-- | Mirror of the production DriverFee table: pkey id, plain skey driverId, and the two pins
+--   that caused the 2026-07 dues incident. dfStatus is a normal column (status is deny-listed
+--   as a key in production) - it must always resolve to in-app filtering.
+data DriverFeeTestT f = DriverFeeTestT
+  { dfId :: B.C f Text,
+    dfDriverId :: B.C f Text,
+    dfFeeType :: B.C f Text,
+    dfServiceName :: B.C f Text,
+    dfStatus :: B.C f Text
+  }
+  deriving (Generic, B.Beamable)
+
+instance B.Table DriverFeeTestT where
+  data PrimaryKey DriverFeeTestT f
+    = DfId (B.C f Text)
+    deriving (Generic, B.Beamable)
+  primaryKey = DfId . dfId
+
+type DriverFeeTest = DriverFeeTestT Identity
+
+$( enableKVPGWithPartialIndex
+     ''DriverFeeTestT
+     ['dfId]
+     [['dfDriverId]]
+     [SKeyPartial [('dfFeeType, "CANCELLATION_PENALTY")], SKeyPartial [('dfServiceName, "YATRI_RENTAL")]]
+ )
+
 row :: Text -> PartialTest
 row st = PartialTestT {id = "id-" <> st, driverId = "d1", status = st}
 
+-- | feeType -> serviceName -> a DriverFee-shaped row for driver d1.
+dfRow :: Text -> Text -> DriverFeeTest
+dfRow ft sn = DriverFeeTestT {dfId = "fee-1", dfDriverId = "d1", dfFeeType = ft, dfServiceName = sn, dfStatus = "PAYMENT_PENDING"}
+
+-- | Which clause fields actually drive redis key lookups for one and-combination - mirrors
+--   getPrimaryKeyFromFieldsAndValues: a field is consulted iff it is in the clause-valid keyMap.
+--   find, findAll, update, updateAll and delete all locate rows through exactly this decision.
+dfResolvesVia :: [(Text, Text)] -> [Text]
+dfResolvesVia combo =
+  sort [k | (k, _) <- combo, HM.member k (validKeyMapForClause (pinnedKeyMap @DriverFeeTest) (keyMap @DriverFeeTest) combo)]
+
+-- | Set memberships an update transition adds/removes - mirrors modifySKeysRedis, which diffs
+--   secondaryKeys of the old row against the new row and SADDs/SREMs accordingly.
+dfSetsJoined :: DriverFeeTest -> DriverFeeTest -> [[(Text, Text)]]
+dfSetsJoined old new = sKeysOf new \\ sKeysOf old
+
+dfSetsLeft :: DriverFeeTest -> DriverFeeTest -> [[(Text, Text)]]
+dfSetsLeft old new = sKeysOf old \\ sKeysOf new
+
+spRow :: Text -> SplitPinTest
+spRow st = SplitPinTestT {spId = "id-" <> st, spStatus = st}
+
+mpRow :: Text -> MultiPinTest
+mpRow st = MultiPinTestT {mpId = "id-" <> st, mpStatus = st}
+
 -- | The raw (field, value) pairs of each secondary key the row currently carries.
-sKeys :: PartialTest -> [[(Text, Text)]]
-sKeys = map (\(SKey s) -> s) . secondaryKeys
+sKeysOf :: KVConnector t => t -> [[(Text, Text)]]
+sKeysOf = map (\(SKey s) -> s) . secondaryKeys
+
+-- | Shorthand: the keyMap 'PartialTest' resolution may use for a given clause combination.
+validFor :: [(Text, Text)] -> HM.HashMap Text Bool
+validFor = validKeyMapForClause (pinnedKeyMap @PartialTest) (keyMap @PartialTest)
 
 partialIndexTests :: TestTree
 partialIndexTests =
   testGroup
     "KV partial index (enableKVPGWithPartialIndex)"
-    [ testCase "ACTIVE row IS indexed under the pinned status key" $
-        sKeys (row "ACTIVE") @?= [[("driverId", "d1")], [("status", "ACTIVE")]],
-      testCase "non-ACTIVE row is NOT indexed under the pinned status key" $
-        sKeys (row "INACTIVE") @?= [[("driverId", "d1")]],
-      testCase "another non-ACTIVE value is also skipped" $
-        sKeys (row "COMPLETED") @?= [[("driverId", "d1")]],
-      testCase "keyMap registers id (pk) + driverId + status" $
-        sort (HM.keys (keyMap @PartialTest)) @?= sort ["id", "driverId", "status"]
+    [ testGroup
+        "write side: secondaryKeys gating"
+        [ testCase "ACTIVE row IS indexed under the pinned status key" $
+            sKeysOf (row "ACTIVE") @?= [[("driverId", "d1")], [("status", "ACTIVE")]],
+          testCase "non-ACTIVE row is NOT indexed under the pinned status key" $
+            sKeysOf (row "INACTIVE") @?= [[("driverId", "d1")]],
+          testCase "another non-ACTIVE value is also skipped" $
+            sKeysOf (row "COMPLETED") @?= [[("driverId", "d1")]],
+          testCase "multi-value pin: first pinned value is indexed" $
+            sKeysOf (mpRow "NEW") @?= [[("mpStatus", "NEW")]],
+          testCase "multi-value pin: second pinned value is indexed (OR, not AND)" $
+            sKeysOf (mpRow "PENDING") @?= [[("mpStatus", "PENDING")]],
+          testCase "multi-value pin: unpinned value is not indexed" $
+            sKeysOf (mpRow "DONE") @?= [],
+          testCase "split specs, same field: each spec's pinned value is indexed" $
+            (sKeysOf (spRow "ACTIVE"), sKeysOf (spRow "INACTIVE")) @?= ([[("spStatus", "ACTIVE")]], [[("spStatus", "INACTIVE")]]),
+          testCase "split specs, same field: unpinned value is not indexed" $
+            sKeysOf (spRow "DONE") @?= []
+        ],
+      testGroup
+        "generated metadata"
+        [ testCase "keyMap registers id (pk) + driverId + status" $
+            sort (HM.keys (keyMap @PartialTest)) @?= sort ["id", "driverId", "status"],
+          testCase "pinnedKeyMap publishes the pin" $
+            pinnedKeyMap @PartialTest @?= HM.fromList [("status", ["ACTIVE"])],
+          testCase "multi-value pin collapses to one keyMap entry (no mpStatus_mpStatus junk)" $
+            sort (HM.keys (keyMap @MultiPinTest)) @?= sort ["mpId", "mpStatus"],
+          testCase "multi-value pin publishes both values" $
+            pinnedKeyMap @MultiPinTest @?= HM.fromList [("mpStatus", ["NEW", "PENDING"])],
+          testCase "plain skey precedence: pin on a plain-keyed field is not published" $
+            pinnedKeyMap @PlainPrecTest @?= HM.empty,
+          testCase "split specs, same field: pinned values merge instead of last-wins" $
+            pinnedKeyMap @SplitPinTest @?= HM.fromList [("spStatus", ["ACTIVE", "INACTIVE"])],
+          testCase "split specs, same field: single keyMap entry" $
+            sort (HM.keys (keyMap @SplitPinTest)) @?= sort ["spId", "spStatus"]
+        ],
+      testGroup
+        "read side: validKeyMapForClause"
+        [ testCase "regular skey present: pinned field dropped even when value matches the pin" $
+            validFor [("driverId", "d1"), ("status", "ACTIVE")]
+              @?= HM.fromList [("id", True), ("driverId", False)],
+          testCase "regular skey present, non-pinned value: pinned field dropped (dues regression)" $
+            validFor [("driverId", "d1"), ("status", "INACTIVE")]
+              @?= HM.fromList [("id", True), ("driverId", False)],
+          testCase "primary key present: pinned field dropped" $
+            validFor [("id", "x"), ("status", "ACTIVE")]
+              @?= HM.fromList [("id", True), ("driverId", False)],
+          testCase "pinned field is the sole key with a pinned value: usable" $
+            validFor [("status", "ACTIVE")] @?= keyMap @PartialTest,
+          testCase "pinned field is the sole key with a non-pinned value: dropped (empty set is not 'no rows')" $
+            validFor [("status", "INACTIVE")]
+              @?= HM.fromList [("id", True), ("driverId", False)],
+          testCase "clause with no key fields at all: keyMap untouched (resolution finds no keys anyway)" $
+            validFor [("someField", "someValue")] @?= keyMap @PartialTest,
+          testCase "table without pins: keyMap always returned unchanged" $
+            validKeyMapForClause (pinnedKeyMap @PlainPrecTest) (keyMap @PlainPrecTest) [("ppStatus", "ANYTHING")]
+              @?= keyMap @PlainPrecTest
+        ],
+      testGroup
+        "DriverFee shape: create"
+        [ testCase "subscription fee: only the driverId set is SADDed" $
+            sKeysOf (dfRow "RECURRING_INVOICE" "YATRI_SUBSCRIPTION") @?= [[("dfDriverId", "d1")]],
+          testCase "cancellation penalty fee: joins the pinned feeType set too" $
+            sKeysOf (dfRow "CANCELLATION_PENALTY" "YATRI_SUBSCRIPTION")
+              @?= [[("dfDriverId", "d1")], [("dfFeeType", "CANCELLATION_PENALTY")]],
+          testCase "rental fee: joins the pinned serviceName set too" $
+            sKeysOf (dfRow "RECURRING_INVOICE" "YATRI_RENTAL")
+              @?= [[("dfDriverId", "d1")], [("dfServiceName", "YATRI_RENTAL")]],
+          testCase "rental cancellation penalty: joins both pinned sets" $
+            sKeysOf (dfRow "CANCELLATION_PENALTY" "YATRI_RENTAL")
+              @?= [[("dfDriverId", "d1")], [("dfFeeType", "CANCELLATION_PENALTY")], [("dfServiceName", "YATRI_RENTAL")]]
+        ],
+      testGroup
+        "DriverFee shape: find / findAll (row location per and-combination)"
+        [ testCase "findById: located via the primary key" $
+            dfResolvesVia [("dfId", "fee-1")] @?= ["dfId"],
+          testCase "dues query (driverId + status + serviceName + feeType): driverId only - the incident regression" $
+            dfResolvesVia [("dfDriverId", "d1"), ("dfStatus", "PAYMENT_PENDING"), ("dfServiceName", "YATRI_SUBSCRIPTION"), ("dfFeeType", "RECURRING_INVOICE")]
+              @?= ["dfDriverId"],
+          testCase "feeType In [..] expands per value: non-pinned value combo uses driverId only" $
+            dfResolvesVia [("dfDriverId", "d1"), ("dfFeeType", "RECURRING_EXECUTION_INVOICE")] @?= ["dfDriverId"],
+          testCase "feeType In [..]: even the pinned-value combo defers to the regular key" $
+            dfResolvesVia [("dfDriverId", "d1"), ("dfFeeType", "CANCELLATION_PENALTY")] @?= ["dfDriverId"],
+          testCase "pinned-only rental query: served from the pinned serviceName set" $
+            dfResolvesVia [("dfServiceName", "YATRI_RENTAL")] @?= ["dfServiceName"],
+          testCase "pinned-only with non-pinned value: no keys, clean DB fallback" $
+            dfResolvesVia [("dfServiceName", "YATRI_SUBSCRIPTION")] @?= [],
+          testCase "two pinned fields, both values pinned, no regular key: both sets usable" $
+            dfResolvesVia [("dfFeeType", "CANCELLATION_PENALTY"), ("dfServiceName", "YATRI_RENTAL")]
+              @?= ["dfFeeType", "dfServiceName"],
+          testCase "two pinned fields, one value not pinned: only the pinned-value field is used" $
+            dfResolvesVia [("dfFeeType", "CANCELLATION_PENALTY"), ("dfServiceName", "YATRI_SUBSCRIPTION")]
+              @?= ["dfFeeType"]
+        ],
+      testGroup
+        "DriverFee shape: update / updateAll / delete (same locator + set transitions)"
+        [ testCase "update by driverId + serviceName (dues clearing): row located via driverId" $
+            dfResolvesVia [("dfDriverId", "d1"), ("dfServiceName", "YATRI_SUBSCRIPTION")] @?= ["dfDriverId"],
+          testCase "updateStatusByIds (id In [..]): each combo located via the primary key" $
+            dfResolvesVia [("dfId", "fee-1")] @?= ["dfId"],
+          testCase "updateAll by driverId In [..] + serviceName: each driver combo located via driverId" $
+            (dfResolvesVia [("dfDriverId", "d1"), ("dfServiceName", "YATRI_SUBSCRIPTION")], dfResolvesVia [("dfDriverId", "d2"), ("dfServiceName", "YATRI_SUBSCRIPTION")])
+              @?= (["dfDriverId"], ["dfDriverId"]),
+          testCase "delete by driverId: located via driverId, pinned fields ignored" $
+            dfResolvesVia [("dfDriverId", "d1"), ("dfFeeType", "RECURRING_INVOICE")] @?= ["dfDriverId"],
+          testCase "update flips feeType to CANCELLATION_PENALTY: row joins the pinned set, leaves none" $
+            ( dfSetsJoined (dfRow "RECURRING_INVOICE" "YATRI_SUBSCRIPTION") (dfRow "CANCELLATION_PENALTY" "YATRI_SUBSCRIPTION"),
+              dfSetsLeft (dfRow "RECURRING_INVOICE" "YATRI_SUBSCRIPTION") (dfRow "CANCELLATION_PENALTY" "YATRI_SUBSCRIPTION")
+            )
+              @?= ([[("dfFeeType", "CANCELLATION_PENALTY")]], []),
+          testCase "update flips feeType back: row leaves the pinned set, joins none" $
+            ( dfSetsJoined (dfRow "CANCELLATION_PENALTY" "YATRI_SUBSCRIPTION") (dfRow "RECURRING_INVOICE" "YATRI_SUBSCRIPTION"),
+              dfSetsLeft (dfRow "CANCELLATION_PENALTY" "YATRI_SUBSCRIPTION") (dfRow "RECURRING_INVOICE" "YATRI_SUBSCRIPTION")
+            )
+              @?= ([], [[("dfFeeType", "CANCELLATION_PENALTY")]]),
+          testCase "update moves service to rental: joins serviceName set, driverId membership untouched" $
+            ( dfSetsJoined (dfRow "RECURRING_INVOICE" "YATRI_SUBSCRIPTION") (dfRow "RECURRING_INVOICE" "YATRI_RENTAL"),
+              dfSetsLeft (dfRow "RECURRING_INVOICE" "YATRI_SUBSCRIPTION") (dfRow "RECURRING_INVOICE" "YATRI_RENTAL")
+            )
+              @?= ([[("dfServiceName", "YATRI_RENTAL")]], []),
+          testCase "status-only update: no set membership changes at all" $
+            ( dfSetsJoined (dfRow "RECURRING_INVOICE" "YATRI_SUBSCRIPTION") ((dfRow "RECURRING_INVOICE" "YATRI_SUBSCRIPTION") {dfStatus = "CLEARED"}),
+              dfSetsLeft (dfRow "RECURRING_INVOICE" "YATRI_SUBSCRIPTION") ((dfRow "RECURRING_INVOICE" "YATRI_SUBSCRIPTION") {dfStatus = "CLEARED"})
+            )
+              @?= ([], [])
+        ]
     ]


### PR DESCRIPTION
The Jul 14 SKeyPartial specs put pinned fields into keyMap, where the euler-hs reader treats every entry as a complete index and intersects SMEMBERS results across all clause fields. Pinned sets are empty for every non-pinned value, so queries carrying serviceName/feeType lost valid driverId/pkey results (driver dues not reflecting after payment).

The TH now also emits KVConnector.pinnedKeyMap (field -> pinned values) so euler-hs can use pinned keys only as a fallback: sole key in the clause AND queried value pinned. Also: same-field pins collapse to one key with OR semantics (fixes Notification's unsatisfiable gate and its junk status_status keyMap entry), fields that also have a plain skey keep full-key behavior (Invoice/Notification unchanged), and pins spanning two different fields are rejected at compile time. Requires euler-hs with KVConnector.pinnedKeyMap.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved partial-index filtering for fields with multiple permitted values.
  - Fixed query results that could be incorrectly omitted when pinned and standard indexes were used together.
  - Corrected create, update, and delete behavior when indexed field values change.
  - Improved handling of multiple partial-index definitions for the same field.
  - Added validation to reject unsupported partial-index configurations early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->