### PR TITLE
fix: add missing space in BecknAPICallError error message formatting

### DIFF
--- a/lib/mobility-core/src/Kernel/Utils/Error/BaseError/HTTPError/BecknAPIError.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Error/BaseError/HTTPError/BecknAPIError.hs
@@ -35,7 +35,7 @@ instance IsBaseError BecknAPICallError where
   toMessage (BecknAPICallError action Error {..}) =
     Just $
       "Beckn " <> action <> " request returned error code " <> code
-        <> maybe "" ("with message: " <>) message
+        <> maybe "" (" with message: " <>) message
 
 instance IsHTTPError BecknAPICallError where
   toErrorCode (BecknAPICallError _ _) = "BECKN_API_CALL_ERROR"


### PR DESCRIPTION
## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description

Adds missing leading space in `BecknAPICallError` error message formatting.

**Before:** `"request returned error code 400with message: some error"`
**After:** `"request returned error code 400 with message: some error"`

Single-character change in `BecknAPIError.hs:38`. Matches the sibling convention already used in `APIError.hs:37`.

### Additional Changes
- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables

## Motivation and Context

Part of the 5xx error reduction work (Bug #7). The missing space causes malformed log messages when a Beckn API call returns an error with a message field — the error code and "with message:" run together with no separator.

## How did you test it?

- Verified only one occurrence exists in the codebase (`grep -rn '"with message:' lib/mobility-core/src/` returns zero results after the fix).
- Confirmed no tests, snapshots, or log parsers assert on the previous (broken) string format.
- Change is a single space in a string literal — no logic or control flow affected.

## Checklist
- [x] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of API error messages by adding proper spacing before optional details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->