### PR TITLE
fix: add config flag to enable fleet engine

### DIFF
--- a/lib/mobility-core/src/Kernel/External/FleetEngine/Config.hs
+++ b/lib/mobility-core/src/Kernel/External/FleetEngine/Config.hs
@@ -32,6 +32,8 @@ import Kernel.Prelude
 data FleetEngineCfg = FleetEngineCfg
   { -- | GCP project id that owns the Fleet Engine provider (the @providers/{id}@ path segment)
     providerId :: Text,
+    -- | Kill switch. 'Nothing' or 'Just False' => integration off; callers should treat absence as off.
+    enabled :: Maybe Bool,
     -- | Fleet Engine REST host; defaults to https://fleetengine.googleapis.com when unset
     fleetEngineUrl :: Maybe BaseUrl,
     -- | Server service-account JSON (ondemandAdmin role) for CreateTrip/UpdateTrip + server tokens, encrypted at rest


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configuration switch to enable or disable the Fleet Engine integration.
  - The integration remains disabled when the setting is left unset or explicitly set to false.
  - Existing configuration options and defaults remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->