### PR TITLE
feat: add intermediateDestinations fields + return updated Trip from …

### DIFF
--- a/lib/mobility-core/src/Kernel/External/FleetEngine/Client.hs
+++ b/lib/mobility-core/src/Kernel/External/FleetEngine/Client.hs
@@ -123,6 +123,9 @@ createTrip baseUrl providerId token tripId trip = do
         logInfo $ "FleetEngine: trip already exists (idempotent no-op) " <> tripId
       | otherwise -> logError $ "FleetEngine: createTrip failed for " <> tripId <> ": " <> show err
 
+-- Returns the server's response Trip on success so callers can cache
+-- 'intermediateDestinationsVersion' for the next mutation; 'Nothing' on
+-- transport or decode failure (log-and-continue, no throws).
 updateTrip ::
   (CoreMetrics m, MonadFlow m, MonadReader r m, HasRequestId r) =>
   BaseUrl ->
@@ -131,7 +134,7 @@ updateTrip ::
   Text -> -- tripId
   Text -> -- updateMask (comma-separated field paths)
   Trip ->
-  m ()
+  m (Maybe Trip)
 updateTrip baseUrl providerId token tripId updateMask trip = do
   result <-
     callAPI
@@ -140,8 +143,16 @@ updateTrip baseUrl providerId token tripId updateMask trip = do
       "fleetEngineUpdateTrip"
       (Proxy :: Proxy UpdateTripAPI)
   case result of
-    Right _ -> logInfo $ "FleetEngine: updated trip " <> tripId <> " [" <> updateMask <> "]"
-    Left err -> logError $ "FleetEngine: updateTrip failed for " <> tripId <> ": " <> show err
+    Right value -> do
+      logInfo $ "FleetEngine: updated trip " <> tripId <> " [" <> updateMask <> "]"
+      case A.fromJSON value of
+        A.Success t -> pure (Just t)
+        A.Error e -> do
+          logError $ "FleetEngine: could not decode updateTrip response for " <> tripId <> ": " <> T.pack e
+          pure Nothing
+    Left err -> do
+      logError $ "FleetEngine: updateTrip failed for " <> tripId <> ": " <> show err
+      pure Nothing
 
 -- | Convenience: advance a trip's status.
 updateTripStatus ::
@@ -153,7 +164,7 @@ updateTripStatus ::
   TripStatus ->
   m ()
 updateTripStatus baseUrl providerId token tripId status =
-  updateTrip baseUrl providerId token tripId "tripStatus" (emptyTrip {tripStatus = Just status})
+  void $ updateTrip baseUrl providerId token tripId "tripStatus" (emptyTrip {tripStatus = Just status})
 
 -- Fleet Engine requires at least one successful CreateVehicle per provider
 -- before any Trips API works (project provisioning); ALREADY_EXISTS is
@@ -214,10 +225,11 @@ assignVehicleAndStart ::
   Text -> -- vehicleId
   m ()
 assignVehicleAndStart baseUrl providerId token tripId vehicleId =
-  updateTrip
-    baseUrl
-    providerId
-    token
-    tripId
-    "tripStatus,vehicleId"
-    (emptyTrip {tripStatus = Just ENROUTE_TO_PICKUP, vehicleId = Just vehicleId})
+  void $
+    updateTrip
+      baseUrl
+      providerId
+      token
+      tripId
+      "tripStatus,vehicleId"
+      (emptyTrip {tripStatus = Just ENROUTE_TO_PICKUP, vehicleId = Just vehicleId})

--- a/lib/mobility-core/src/Kernel/External/FleetEngine/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/FleetEngine/Types.hs
@@ -59,7 +59,12 @@ data Trip = Trip
     vehicleId :: Maybe Text,
     numberOfPassengers :: Maybe Int,
     pickupPoint :: Maybe TerminalLocation,
-    dropoffPoint :: Maybe TerminalLocation
+    dropoffPoint :: Maybe TerminalLocation,
+    intermediateDestinations :: Maybe [TerminalLocation],
+    -- Opaque RFC3339 timestamp; must be echoed back on every
+    -- intermediateDestinations mutation (server-side optimistic lock).
+    intermediateDestinationsVersion :: Maybe Text,
+    intermediateDestinationIndex :: Maybe Int
   }
   deriving (Show, Eq, Generic)
 
@@ -80,7 +85,10 @@ emptyTrip =
       vehicleId = Nothing,
       numberOfPassengers = Nothing,
       pickupPoint = Nothing,
-      dropoffPoint = Nothing
+      dropoffPoint = Nothing,
+      intermediateDestinations = Nothing,
+      intermediateDestinationsVersion = Nothing,
+      intermediateDestinationIndex = Nothing
     }
 
 -- | Build the CreateTrip body. Fleet Engine requires @tripType@; pickup/dropoff


### PR DESCRIPTION
…updateTrip

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fleet Engine trip updates now return the refreshed trip details when available, supporting continued trip updates.
  * Trip data now supports intermediate destinations, destination versioning, and the current destination index.

* **Bug Fixes**
  * Trip update failures continue to be handled gracefully without interrupting related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->