### PR TITLE
fix: do not send null data to the ovelay notification.

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Notification/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Notification/Interface/Types.hs
@@ -25,6 +25,7 @@ import qualified Kernel.External.Notification.GRPC.Types as GRPC
 import qualified Kernel.External.Notification.PayTM.Types as PayTM
 import qualified Kernel.External.Notification.Types as Interface
 import Kernel.Prelude
+import Kernel.Utils.JSON (removeNullFields)
 
 data NotificationServiceConfig = FCMConfig FCM.FCMConfig | PayTMConfig PayTM.PayTMConfig | GRPCConfig GRPC.GRPCConfig
   deriving (Show, Eq, Generic, ToJSON, FromJSON)
@@ -204,7 +205,10 @@ data OverlayNotificationData = OverlayNotificationData
     socialMediaLinks :: Maybe [FCMMediaLink],
     showPushNotification :: Maybe Bool
   }
-  deriving (Eq, Show, Generic, ToJSON, FromJSON)
+  deriving (Eq, Show, Generic, FromJSON)
+
+instance ToJSON OverlayNotificationData where
+  toJSON = genericToJSON removeNullFields
 
 data NotificationReq a b = NotificationReq
   { auth :: Auth,


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications now omit empty or null fields from their JSON data, resulting in cleaner and more consistent payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->