### PR TITLE
feat: route configured tables to a dedicated critical DB-sync stream

### DIFF
--- a/lib/mobility-core/src/Kernel/Beam/Functions.hs
+++ b/lib/mobility-core/src/Kernel/Beam/Functions.hs
@@ -166,6 +166,16 @@ runInMultiCloud m = do
 allowedSchema :: [Text]
 allowedSchema = ["atlas_driver_offer_bpp", "atlas_app"]
 
+getRedisStreamName :: Text -> Text -> Tables -> Text
+getRedisStreamName modelName schema tables'
+  | isCriticalTable = baseStream <> "-critical"
+  | otherwise = baseStream
+  where
+    baseStream
+      | schema == "atlas_driver_offer_bpp" = "driver-db-sync-stream"
+      | otherwise = "rider-db-sync-stream" -- lets change when we enable for dashboards
+    isCriticalTable = modelName `elem` fromMaybe [] tables'.tablesForCriticalStream
+
 -- | Resolve schema, enforce 'allowedSchema', then merge KV/Redis settings from @tables'@.
 -- Schema check lives only here — callers pass an already-loaded 'Tables' so it is fetched once.
 setMeshConfigWithTables :: (L.MonadFlow m, HasCallStack) => Text -> Maybe Text -> MeshConfig -> Tables -> m MeshConfig
@@ -175,7 +185,7 @@ setMeshConfigWithTables modelName mSchema meshConfig' tables' = do
     if schema `notElem` allowedSchema
       then meshConfig'
       else
-        let redisStream = if schema == "atlas_driver_offer_bpp" then "driver-db-sync-stream" else "rider-db-sync-stream" -- lets change when we enable for dashboards
+        let redisStream = getRedisStreamName modelName schema tables'
          in if modelName `elem` tables'.disableForKV || allTablesDisabled tables' == Just True
               then meshConfig' {ecRedisDBStream = redisStream}
               else

--- a/lib/mobility-core/src/Kernel/Beam/Functions.hs
+++ b/lib/mobility-core/src/Kernel/Beam/Functions.hs
@@ -153,7 +153,8 @@ runInMasterDbAndRedis m = do
 
 -- | Run a findAll query with multi-cloud Redis enabled.
 -- When enabled, findAll queries will read from both primary and secondary Redis instances.
--- The same behaviour is enabled globally when Tables.enableFindAllForMultiCloud is Just True.
+-- The same behaviour is enabled automatically for tables in tablesForSecondaryCloudRead,
+-- and globally when Tables.enableFindAllForMultiCloud is Just True.
 -- Note: This only affects findAll KV helpers (see 'withUpdatedMeshConfigForFindAll').
 -- Other operations (findOne, update, delete, create) are not affected.
 runInMultiCloud :: (L.MonadFlow m, Log m) => m a -> m a
@@ -223,16 +224,15 @@ withUpdatedMeshConfig _ mkAction = do
   mkAction updatedMeshConfig
 
 -- | Get mesh config for findAll queries with multi-cloud support.
--- Sets secondaryRedisEnabled when runInMultiCloud is active or
--- Tables.enableFindAllForMultiCloud is Just True; otherwise forces it off for findAll.
+-- Sets secondaryRedisEnabled when runInMultiCloud is active, the table is in
+-- tablesForSecondaryCloudRead, or Tables.enableFindAllForMultiCloud is
+-- Just True; otherwise forces it off for findAll.
 setMeshConfigForFindAll :: (L.MonadFlow m, HasCallStack) => Text -> Maybe Text -> MeshConfig -> m MeshConfig
 setMeshConfigForFindAll modelName mSchema meshConfig' = do
   tables' <- getTablesOption
   baseMeshConfig <- setMeshConfigWithTables modelName mSchema meshConfig' tables'
   isMultiCloudEnabled <- L.getOptionLocal MultiCloudEnabled
-  let findAllMultiCloudOn =
-        fromMaybe False isMultiCloudEnabled
-          || tables'.enableFindAllForMultiCloud == Just True
+  let findAllMultiCloudOn = tables'.enableFindAllForMultiCloud == Just True || modelName `elem` fromMaybe [] tables'.tablesForSecondaryCloudRead || fromMaybe False isMultiCloudEnabled
   pure baseMeshConfig {secondaryRedisEnabled = findAllMultiCloudOn}
 
 withUpdatedMeshConfigForFindAll :: forall table m a. (L.MonadFlow m, HasCallStack, ModelMeta table) => Proxy table -> (MeshConfig -> m a) -> m a

--- a/lib/mobility-core/src/Kernel/Types/Common.hs
+++ b/lib/mobility-core/src/Kernel/Types/Common.hs
@@ -82,7 +82,8 @@ data Tables = Tables
     enableAllTablesForSecondaryCloudRead :: Maybe Bool,
     tablesForRecacheFind :: Maybe [Text],
     drainerTtlConfigs :: Maybe (HM.HashMap Text Integer),
-    enableFindAllForMultiCloud :: Maybe Bool
+    enableFindAllForMultiCloud :: Maybe Bool,
+    tablesForCriticalStream :: Maybe [Text]
   }
   deriving (Generic, Show, ToJSON, FromJSON, FromDhall)
 
@@ -103,7 +104,8 @@ defaultTableData =
       enableAllTablesForSecondaryCloudRead = Nothing,
       tablesForRecacheFind = Nothing,
       drainerTtlConfigs = Nothing,
-      enableFindAllForMultiCloud = Nothing
+      enableFindAllForMultiCloud = Nothing,
+      tablesForCriticalStream = Nothing
     }
 
 data KafkaProperties = KafkaProperties


### PR DESCRIPTION
## Description

### Critical DB-sync stream
Adds a new optional field `tablesForCriticalStream :: Maybe [Text]` to the `Tables` KV config (`kv_configs` in `system_configs`). Any table listed there gets its KV DB-sync commands pushed to a dedicated Redis stream `<base>-db-sync-stream-critical{shard-N}` (e.g. `driver-db-sync-stream-critical`) instead of the normal stream, so dedicated drainer threads can drain critical tables independently of the normal backlog. Companion drainer PR: nammayatri/nammayatri#16145.

### Multi-cloud findAll for secondary-read tables
`setMeshConfigForFindAll` now enables secondary-Redis reads when ANY of these hold: the call site is wrapped in `runInMultiCloud`, the table is listed in `tablesForSecondaryCloudRead`, or `enableFindAllForMultiCloud` is `Just True`. Previously the per-table secondary-read config was ignored (forced off) on the findAll path, so findAll could miss rows living in the secondary cloud's Redis.

## Notes
- Backward compatible: missing `tablesForCriticalStream` key in `kv_configs` JSON decodes to `Nothing` (no behavior change).
- No euler-hs change needed: it pushes to `meshCfg.ecRedisDBStream <> "{shard-N}"` verbatim; the shard tag is independent of the stream name.
- Verified: `cabal build lib:mobility-core` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)