### PR TITLE
backend/feat: add scheduler job lifecycle counter

### DIFF
--- a/lib/mobility-core/src/Kernel/Mock/App.hs
+++ b/lib/mobility-core/src/Kernel/Mock/App.hs
@@ -64,6 +64,7 @@ instance CoreMetrics (MockM e) where
   addGenericLatency _ _ = return ()
   incrementSchedulerFailureCounter _ = return ()
   incrementSchedulerJobDisabledCounter _ = return ()
+  incrementSchedulerJobLifecycleCounter _ _ = return ()
   incrementProducerError _ = return ()
   incrementGenericMetrics _ = return ()
   incrementConfigPilotSuccessCounter _ = return ()

--- a/lib/mobility-core/src/Kernel/Mock/App.hs
+++ b/lib/mobility-core/src/Kernel/Mock/App.hs
@@ -65,6 +65,7 @@ instance CoreMetrics (MockM e) where
   incrementSchedulerFailureCounter _ = return ()
   incrementSchedulerJobDisabledCounter _ = return ()
   incrementSchedulerJobLifecycleCounter _ _ = return ()
+  addSchedulerProducerStageCount _ _ = return ()
   incrementProducerError _ = return ()
   incrementGenericMetrics _ = return ()
   incrementConfigPilotSuccessCounter _ = return ()

--- a/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics.hs
+++ b/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics.hs
@@ -308,6 +308,27 @@ incrementSchedulerFailureCounterImplementation' cmContainers context version = d
       (context, version.getDeploymentVersion)
       P.incCounter
 
+incrementSchedulerJobLifecycleCounterImplementation ::
+  ( HasCoreMetrics r,
+    L.MonadFlow m,
+    MonadReader r m
+  ) =>
+  Text ->
+  Text ->
+  m ()
+incrementSchedulerJobLifecycleCounterImplementation jobType status = do
+  cmContainer <- asks (.coreMetrics)
+  version <- asks (.version)
+  incrementSchedulerJobLifecycleCounterImplementation' cmContainer jobType status version
+
+incrementSchedulerJobLifecycleCounterImplementation' :: L.MonadFlow m => CoreMetricsContainer -> Text -> Text -> DeploymentVersion -> m ()
+incrementSchedulerJobLifecycleCounterImplementation' cmContainers jobType status version =
+  L.runIO $
+    P.withLabel
+      cmContainers.schedulerJobLifecycleCounter
+      (jobType, status, version.getDeploymentVersion)
+      P.incCounter
+
 incrementSchedulerJobDisabledCounterImplementation' :: L.MonadFlow m => CoreMetricsContainer -> Text -> DeploymentVersion -> m ()
 incrementSchedulerJobDisabledCounterImplementation' cmContainers context version = do
   let sortedSetMetric = cmContainers.schedulerJobDisabledCounter

--- a/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics.hs
+++ b/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics.hs
@@ -329,6 +329,29 @@ incrementSchedulerJobLifecycleCounterImplementation' cmContainers jobType status
       (jobType, status, version.getDeploymentVersion)
       P.incCounter
 
+addSchedulerProducerStageCountImplementation ::
+  ( HasCoreMetrics r,
+    L.MonadFlow m,
+    MonadReader r m
+  ) =>
+  Text ->
+  Int ->
+  m ()
+addSchedulerProducerStageCountImplementation stage n = do
+  cmContainer <- asks (.coreMetrics)
+  version <- asks (.version)
+  addSchedulerProducerStageCountImplementation' cmContainer stage n version
+
+addSchedulerProducerStageCountImplementation' :: L.MonadFlow m => CoreMetricsContainer -> Text -> Int -> DeploymentVersion -> m ()
+addSchedulerProducerStageCountImplementation' cmContainers stage n version =
+  -- addCounter rejects negative deltas; skip the no-op case entirely.
+  when (n > 0) $
+    L.runIO $
+      P.withLabel
+        cmContainers.schedulerProducerStageCounter
+        (stage, version.getDeploymentVersion)
+        (\c -> void $ P.addCounter c (fromIntegral n))
+
 incrementSchedulerJobDisabledCounterImplementation' :: L.MonadFlow m => CoreMetricsContainer -> Text -> DeploymentVersion -> m ()
 incrementSchedulerJobDisabledCounterImplementation' cmContainers context version = do
   let sortedSetMetric = cmContainers.schedulerJobDisabledCounter

--- a/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics/Types.hs
+++ b/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics/Types.hs
@@ -52,6 +52,11 @@ type SchedulerFailureMetric = P.Vector P.Label2 P.Counter
 
 type SchedulerJobDisabledMetric = P.Vector P.Label2 P.Counter
 
+-- | Scheduler job lifecycle counter (labels: "job_type", "status", "version").
+-- Covers the whole life of a job -- created, picked and every terminal
+-- outcome -- so a single query can compare them per job type.
+type SchedulerJobLifecycleMetric = P.Vector P.Label3 P.Counter
+
 type ProducerErrorMetric = P.Vector P.Label2 P.Counter
 
 type GenericCounter = P.Vector P.Label1 P.Counter
@@ -102,6 +107,10 @@ class CoreMetrics m where
   addGenericLatency :: Text -> Milliseconds -> m ()
   incrementSchedulerFailureCounter :: Text -> m ()
   incrementSchedulerJobDisabledCounter :: Text -> m ()
+
+  -- | @incrementSchedulerJobLifecycleCounter jobType status@ -- record a job
+  -- lifecycle transition. See "Lib.Scheduler.Metrics" for the status values.
+  incrementSchedulerJobLifecycleCounter :: Text -> Text -> m ()
   incrementProducerError :: Text -> m ()
   incrementGenericMetrics :: Text -> m ()
   incrementConfigPilotSuccessCounter :: Text -> m ()
@@ -132,6 +141,7 @@ data CoreMetricsContainer = CoreMetricsContainer
     streamFailedCounter :: StreamFailedMetric,
     schedulerFailureCounter :: SchedulerFailureMetric,
     schedulerJobDisabledCounter :: SchedulerJobDisabledMetric,
+    schedulerJobLifecycleCounter :: SchedulerJobLifecycleMetric,
     producerError :: ProducerErrorMetric,
     genericCounter :: GenericCounter,
     systemConfigsFailedCounter :: SystemConfigsFailedCounter,
@@ -164,6 +174,7 @@ registerCoreMetricsContainer = do
   streamFailedCounter <- registerStreamFailedCounter
   schedulerFailureCounter <- registerSchedulerFailureCounter
   schedulerJobDisabledCounter <- registerSchedulerJobDisabledCounter
+  schedulerJobLifecycleCounter <- registerSchedulerJobLifecycleCounter
   producerError <- registerProducerErrorMetric
   genericCounter <- registerGenericCounter
   systemConfigsFailedCounter <- registerSystemConfigsFailedCounter
@@ -277,6 +288,14 @@ registerSchedulerJobDisabledCounter =
       P.counter info
   where
     info = P.Info "scheduler_jobs_disabled_counter" ""
+
+registerSchedulerJobLifecycleCounter :: IO SchedulerJobLifecycleMetric
+registerSchedulerJobLifecycleCounter =
+  P.register $
+    P.vector ("job_type", "status", "version") $
+      P.counter info
+  where
+    info = P.Info "scheduler_job_lifecycle_counter" "Scheduler job transitions per job type, labelled by lifecycle status (created/picked/completed/failed/rescheduled/retried/retry_exhausted/duplicate)"
 
 registerProducerErrorMetric :: IO ProducerErrorMetric
 registerProducerErrorMetric =

--- a/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics/Types.hs
+++ b/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics/Types.hs
@@ -57,6 +57,14 @@ type SchedulerJobDisabledMetric = P.Vector P.Label2 P.Counter
 -- outcome -- so a single query can compare them per job type.
 type SchedulerJobLifecycleMetric = P.Vector P.Label3 P.Counter
 
+-- | Producer pipeline stage counter (labels: "stage", "version").
+--
+-- Counts jobs moving through the producer: read out of the scheduled sorted
+-- set, then written into the redis stream. Deliberately has no @job_type@
+-- label -- the producer handles opaque encoded job blobs and does not parse
+-- them, so tagging by type would mean decoding every job on the hot path.
+type SchedulerProducerStageMetric = P.Vector P.Label2 P.Counter
+
 type ProducerErrorMetric = P.Vector P.Label2 P.Counter
 
 type GenericCounter = P.Vector P.Label1 P.Counter
@@ -111,6 +119,11 @@ class CoreMetrics m where
   -- | @incrementSchedulerJobLifecycleCounter jobType status@ -- record a job
   -- lifecycle transition. See "Lib.Scheduler.Metrics" for the status values.
   incrementSchedulerJobLifecycleCounter :: Text -> Text -> m ()
+
+  -- | @addSchedulerProducerStageCount stage n@ -- record that @n@ jobs passed
+  -- through a producer pipeline stage. Takes a count because the producer
+  -- moves jobs in batches.
+  addSchedulerProducerStageCount :: Text -> Int -> m ()
   incrementProducerError :: Text -> m ()
   incrementGenericMetrics :: Text -> m ()
   incrementConfigPilotSuccessCounter :: Text -> m ()
@@ -142,6 +155,7 @@ data CoreMetricsContainer = CoreMetricsContainer
     schedulerFailureCounter :: SchedulerFailureMetric,
     schedulerJobDisabledCounter :: SchedulerJobDisabledMetric,
     schedulerJobLifecycleCounter :: SchedulerJobLifecycleMetric,
+    schedulerProducerStageCounter :: SchedulerProducerStageMetric,
     producerError :: ProducerErrorMetric,
     genericCounter :: GenericCounter,
     systemConfigsFailedCounter :: SystemConfigsFailedCounter,
@@ -175,6 +189,7 @@ registerCoreMetricsContainer = do
   schedulerFailureCounter <- registerSchedulerFailureCounter
   schedulerJobDisabledCounter <- registerSchedulerJobDisabledCounter
   schedulerJobLifecycleCounter <- registerSchedulerJobLifecycleCounter
+  schedulerProducerStageCounter <- registerSchedulerProducerStageCounter
   producerError <- registerProducerErrorMetric
   genericCounter <- registerGenericCounter
   systemConfigsFailedCounter <- registerSystemConfigsFailedCounter
@@ -296,6 +311,14 @@ registerSchedulerJobLifecycleCounter =
       P.counter info
   where
     info = P.Info "scheduler_job_lifecycle_counter" "Scheduler job transitions per job type, labelled by lifecycle status (created/picked/completed/failed/rescheduled/retried/retry_exhausted/duplicate)"
+
+registerSchedulerProducerStageCounter :: IO SchedulerProducerStageMetric
+registerSchedulerProducerStageCounter =
+  P.register $
+    P.vector ("stage", "version") $
+      P.counter info
+  where
+    info = P.Info "scheduler_producer_stage_counter" "Jobs moving through the producer pipeline, by stage (picked_from_set/inserted_to_stream/stream_insert_failed)"
 
 registerProducerErrorMetric :: IO ProducerErrorMetric
 registerProducerErrorMetric =

--- a/lib/mobility-core/src/Kernel/Types/Flow.hs
+++ b/lib/mobility-core/src/Kernel/Types/Flow.hs
@@ -228,6 +228,7 @@ instance Metrics.HasCoreMetrics r => Metrics.CoreMetrics (FlowR r) where
   addGenericLatency = Metrics.addGenericLatencyImplementation
   incrementSchedulerFailureCounter = Metrics.incrementSchedulerFailureCounterImplementation
   incrementSchedulerJobDisabledCounter = Metrics.incrementSchedulerJobDisabledCounterImplementation
+  incrementSchedulerJobLifecycleCounter = Metrics.incrementSchedulerJobLifecycleCounterImplementation
   incrementProducerError = Metrics.incrementProducerErrorImplementation
   incrementGenericMetrics = Metrics.incrementGenericMetrics'
   incrementConfigPilotSuccessCounter = Metrics.incrementConfigPilotSuccessCounter'

--- a/lib/mobility-core/src/Kernel/Types/Flow.hs
+++ b/lib/mobility-core/src/Kernel/Types/Flow.hs
@@ -229,6 +229,7 @@ instance Metrics.HasCoreMetrics r => Metrics.CoreMetrics (FlowR r) where
   incrementSchedulerFailureCounter = Metrics.incrementSchedulerFailureCounterImplementation
   incrementSchedulerJobDisabledCounter = Metrics.incrementSchedulerJobDisabledCounterImplementation
   incrementSchedulerJobLifecycleCounter = Metrics.incrementSchedulerJobLifecycleCounterImplementation
+  addSchedulerProducerStageCount = Metrics.addSchedulerProducerStageCountImplementation
   incrementProducerError = Metrics.incrementProducerErrorImplementation
   incrementGenericMetrics = Metrics.incrementGenericMetrics'
   incrementConfigPilotSuccessCounter = Metrics.incrementConfigPilotSuccessCounter'

--- a/lib/mobility-core/test/src/APIExceptions.hs
+++ b/lib/mobility-core/test/src/APIExceptions.hs
@@ -65,6 +65,7 @@ instance Metrics.CoreMetrics IO where
   incrementSchedulerFailureCounter _ = return ()
   incrementSchedulerJobDisabledCounter _ = return ()
   incrementSchedulerJobLifecycleCounter _ _ = return ()
+  addSchedulerProducerStageCount _ _ = return ()
   incrementGenericMetrics _ = return ()
   incrementConfigPilotSuccessCounter _ = return ()
   incrementConfigPilotFailureCounter _ = return ()

--- a/lib/mobility-core/test/src/APIExceptions.hs
+++ b/lib/mobility-core/test/src/APIExceptions.hs
@@ -64,6 +64,7 @@ instance Metrics.CoreMetrics IO where
   addGenericLatency _ _ = return ()
   incrementSchedulerFailureCounter _ = return ()
   incrementSchedulerJobDisabledCounter _ = return ()
+  incrementSchedulerJobLifecycleCounter _ _ = return ()
   incrementGenericMetrics _ = return ()
   incrementConfigPilotSuccessCounter _ = return ()
   incrementConfigPilotFailureCounter _ = return ()


### PR DESCRIPTION
## What

Adds `scheduler_job_lifecycle_counter{job_type, status, version}` — one counter covering the whole life of a scheduler job.

Statuses: `created` · `picked` · `completed` · `failed` · `rescheduled` · `retried` · `retry_exhausted` · `duplicate`

## Why

Only three of these points are instrumented today, spread across three separately named metrics with inconsistent labels:

| Point | Today |
|---|---|
| completed | `stream_jobs_counter` |
| failed | `stream_jobs_failed_counter` |
| retry exhausted | `scheduler_jobs_fail_counter` (labelled `scheduler_type`, not `job_type`) |
| **created** | not counted |
| **retried** (within budget) | not counted |
| **rescheduled** | not counted |
| **duplicate** | not counted |

Because job *creation* isn't counted, there's no way to compare jobs entering the scheduler against jobs leaving it. That comparison is exactly the signal that would have surfaced the 2026-08-11 allocator stall directly, independent of the producer that caused it:

```promql
sum(rate(scheduler_job_lifecycle_counter{status="created"}[5m])) by (job_type)
  - sum(rate(scheduler_job_lifecycle_counter{status=~"completed|failed|retry_exhausted"}[5m])) by (job_type)
```

## Notes

- **Purely additive** — the three existing counters are untouched, so current dashboards keep working.
- The new metric uses the bare job type (`SendSearchRequestToDriver`). The older call sites apply `show` to an already-`Text` value, which is why their `job_type` labels carry embedded quotes (`Executor_"SendSearchRequestToDriver"`). Not changed here to avoid breaking existing queries.
- The method is implemented on all three `CoreMetrics` instances: `FlowR r`, `MockM e`, and the `IO` instance in the test suite.

## Testing

`mobility-core` library **and** its test suite build clean.

Downstream call sites live in nammayatri (`Lib/Scheduler/{Metrics,Environment,ScheduleJob,Handler}.hs`). That branch was validated against this exact patch applied to the currently pinned rev — `scheduler` lib, `driver-offer-allocator` (1824 modules) and `rider-app` + `producer` (1617 modules) all build and link.

Merge this first, then the nammayatri PR bumps `flake.lock` to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for scheduler job lifecycle events.
  * Lifecycle metrics include job type, status, and deployment version labels.
  * Added metrics for scheduler producer pipeline stages, including deployment version.
  * Producer stage counts record positive values while ignoring zero or negative updates.
  * Scheduler metrics are now recorded across supported runtime environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->