### PR TITLE
Backend/enh/adding-TxnIdKey-to-forks-MVar

### DIFF
--- a/lib/mobility-core/src/Kernel/Beam/Types.hs
+++ b/lib/mobility-core/src/Kernel/Beam/Types.hs
@@ -104,3 +104,10 @@ data MultiCloudEnabled = MultiCloudEnabled
   deriving anyclass (ToJSON, FromJSON)
 
 instance OptionEntity MultiCloudEnabled Bool
+
+-- Transaction id carried across forked flows (see 'Kernel.Types.Flow.carryForkLocalOptions')
+data TxnIdKey = TxnIdKey
+  deriving stock (Generic, Typeable, Show, Eq)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance OptionEntity TxnIdKey Text

--- a/lib/mobility-core/src/Kernel/Types/Flow.hs
+++ b/lib/mobility-core/src/Kernel/Types/Flow.hs
@@ -26,6 +26,7 @@ import qualified EulerHS.Language as L
 import EulerHS.Prelude
 import qualified EulerHS.Runtime as R
 import Kernel.Beam.Lib.UtilsTH
+import qualified Kernel.Beam.Types as KBT
 import Kernel.Prelude hiding (forM_, mapM_)
 import Kernel.Storage.Beam.SystemConfigs
 import Kernel.Storage.Esqueleto.Config
@@ -253,17 +254,20 @@ instance MonadGuid (FlowR r) where
 
 instance (Log (FlowR r), Metrics.CoreMetrics (FlowR r), HasARTFlow r) => Forkable (FlowR r) where
   fork tag f = withLogTag ("Fork " <> tag) $ do
+    seedLocalOptions <- carryForkLocalOptions
     newLocalOptions <- newMVar mempty
     -- logRequestIdForFork tag
-    FlowR $ ReaderT $ L.forkFlow tag . L.withModifiedRuntime (refreshLocalOptions newLocalOptions) . runReaderT (unFlowR $ handleForkExecution tag f)
+    FlowR $ ReaderT $ L.forkFlow tag . L.withModifiedRuntime (refreshLocalOptions newLocalOptions) . runReaderT (unFlowR $ seedLocalOptions >> handleForkExecution tag f)
 
   forkMultiple tagAndFunction = do
+    seedLocalOptions <- carryForkLocalOptions
     newLocalOptions <- newMVar mempty
-    FlowR $ ReaderT $ L.forkFlow "multiple-Forks" . L.withModifiedRuntime (refreshLocalOptions newLocalOptions) . runReaderT (unFlowR $ handleForkExecutionMultiple tagAndFunction)
+    FlowR $ ReaderT $ L.forkFlow "multiple-Forks" . L.withModifiedRuntime (refreshLocalOptions newLocalOptions) . runReaderT (unFlowR $ seedLocalOptions >> handleForkExecutionMultiple tagAndFunction)
 
   awaitableFork tag f = do
+    seedLocalOptions <- carryForkLocalOptions
     newLocalOptions <- newMVar mempty
-    FlowR $ ReaderT $ L.forkFlow' tag . L.withModifiedRuntime (refreshLocalOptions newLocalOptions) . runReaderT (unFlowR $ handleExc f)
+    FlowR $ ReaderT $ L.forkFlow' tag . L.withModifiedRuntime (refreshLocalOptions newLocalOptions) . runReaderT (unFlowR $ seedLocalOptions >> handleExc f)
     where
       handleExc f' = do
         res <- try f'
@@ -310,3 +314,9 @@ handleForkExecution tag f = try f >>= (`whenLeft` err)
 
 refreshLocalOptions :: MVar (M.Map Text Any) -> R.FlowRuntime -> R.FlowRuntime
 refreshLocalOptions newLocalOptions flowRt = flowRt {R._optionsLocal = newLocalOptions}
+
+-- | Local options that must be inherited by a forked flow.
+carryForkLocalOptions :: FlowR r (FlowR r ())
+carryForkLocalOptions = do
+  mTxnId <- L.getOptionLocal KBT.TxnIdKey
+  pure $ maybe (pure ()) (L.setOptionLocal KBT.TxnIdKey) mTxnId


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction tracking across forked and parallel flows.
  - Local transaction IDs are now preserved when work is split into child flows and restored when those flows continue.
  - This helps maintain consistent transaction context across asynchronous and forked operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->