### PR TITLE
feat: add updateOneWithLockKV function and related KVLockConfig imports

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -387,11 +387,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785155093,
-        "narHash": "sha256-NiUhGV6Y/nyQu2HT13LLA2Zdy6u92P4A9vd8p9NSmvU=",
+        "lastModified": 1787042391,
+        "narHash": "sha256-jzw8rcK4ko89AY8agtZrg9gKXrgN+jrr+AKsgOS52jE=",
         "owner": "nammayatri",
         "repo": "euler-hs",
-        "rev": "4badf9391c3bf9805bb8b9177c0da6ee49784d58",
+        "rev": "6290a7e3bad44e786621f016fa1991ecb48b9802",
         "type": "github"
       },
       "original": {

--- a/lib/mobility-core/src/Kernel/Beam/Functions.hs
+++ b/lib/mobility-core/src/Kernel/Beam/Functions.hs
@@ -22,6 +22,9 @@ module Kernel.Beam.Functions
     updateWithKV,
     updateWithKVScheduler,
     updateOneWithKV,
+    updateOneWithLockKV,
+    defaultKVLockConfig,
+    KVLockConfig (..),
     createWithKV,
     createWithKVScheduler,
     deleteWithKV,
@@ -52,7 +55,7 @@ import Database.Beam.Postgres
 import EulerHS.Extra.Monitoring.Types (UseMasterRedis (..))
 import EulerHS.JsonbFallback (GFieldNames)
 import qualified EulerHS.KVConnector.Flow as KV
-import EulerHS.KVConnector.Types (KVConnector (..), MeshConfig (..), MeshMeta, TableMappings)
+import EulerHS.KVConnector.Types (KVConnector (..), KVLockConfig (..), MeshConfig (..), MeshMeta, TableMappings, defaultKVLockConfig)
 import EulerHS.KVConnector.Utils
 import qualified EulerHS.Language as L
 import EulerHS.Types hiding (Log, V1)
@@ -574,6 +577,28 @@ updateOneWithKVWithOptions ::
 updateOneWithKVWithOptions ttl forceDrain setClause whereClause = withUpdatedMeshConfig (Proxy @table) $ \updatedMeshConfig -> do
   let updatedMeshConfig' = updatedMeshConfig {redisTtl = fromMaybe (redisTtl updatedMeshConfig) ttl, forceDrainToDB = forceDrain}
   updateOneInternal updatedMeshConfig' setClause whereClause
+
+updateOneWithLockKV ::
+  forall table m r.
+  (BeamTableFlow table m, EsqDBFlow m r) =>
+  KVLockConfig ->
+  (table Identity -> [Set Postgres table]) ->
+  Where Postgres table ->
+  m ()
+updateOneWithLockKV lockCfg mkSetClause whereClause = withUpdatedMeshConfig (Proxy @table) $ \updatedMeshConfig ->
+  runInMasterRedis $ do
+    dbConf <- getMasterDBConfig
+    replicaDbConf <- getReplicaDbConfig
+    res <- KV.updateOneWithLockKVConnector dbConf replicaDbConf updatedMeshConfig lockCfg mkSetClause whereClause
+    case res of
+      Right obj ->
+        unless (updatedMeshConfig.meshEnabled && not updatedMeshConfig.kvHardKilled) $
+          whenJust obj $ \object' -> do
+            topicName <- getKafkaTopic (modelSchemaName @table) (modelTableName @table)
+            let newObject = replaceMappings (toJSON object') (getMappings [object'])
+            handle (\(e :: SomeException) -> L.logError ("KAFKA_PUSH_FAILED" :: Text) $ "Kafka push error while update: " <> show e <> "in topic" <> topicName) $
+              void $ pushToKafka newObject topicName (getKeyForKafka updatedMeshConfig.tableShardModRange $ getLookupKeyByPKey updatedMeshConfig.redisKeyPrefix object')
+      Left err -> throwError $ InternalError $ show err
 
 -- create --
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating records through the key-value store with configurable locking.
  * Updated records can be synchronized to Kafka when key-value storage is unavailable or disabled.

* **Reliability Improvements**
  * Key-value connector failures now return an internal error.
  * Kafka publishing failures are logged without preventing the record update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->