### PR TITLE
backend/enhancement: sender-controlled stale-date for live activity push

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Notification/FCM/Flow.hs
+++ b/lib/mobility-core/src/Kernel/External/Notification/FCM/Flow.hs
@@ -337,8 +337,10 @@ updateLiveActivity ::
   FCMConfig ->
   FCMNotificationRecipient ->
   LiveActivityReq ->
+  -- | APNs @stale-date@; when set, the sender controls when the activity goes stale.
+  Maybe Int ->
   m ()
-updateLiveActivity config recipient apnsReq = do
+updateLiveActivity config recipient apnsReq mbStaleDate = do
   let tokenNotFound = "device token of a person " <> recipient.id <> " not found"
   case recipient.token of
     Nothing -> do
@@ -348,7 +350,7 @@ updateLiveActivity config recipient apnsReq = do
       currentTime <- liftIO getPOSIXTime
       let currentTimeInt = floor currentTime :: Int
           apnsReqTimeStamp = currentTimeInt
-      sendLiveActivityApns config (createApnsLiveActivtyPayload token apnsReq apnsReqTimeStamp) recipient.id
+      sendLiveActivityApns config (createApnsLiveActivtyPayload token apnsReq apnsReqTimeStamp mbStaleDate) recipient.id
 
 sendLiveActivityApns ::
   ( CoreMetrics m,
@@ -389,8 +391,8 @@ data ResponseType = ResponseType
 apnsLiveActivityAPI :: Proxy (ApnsLiveActivityAPI a)
 apnsLiveActivityAPI = Proxy
 
-createApnsLiveActivtyPayload :: FCMRecipientToken -> LiveActivityReq -> Int -> ApnsAPIRequest
-createApnsLiveActivtyPayload receipentToken apnsReq apnsReqTimeStamp =
+createApnsLiveActivtyPayload :: FCMRecipientToken -> LiveActivityReq -> Int -> Maybe Int -> ApnsAPIRequest
+createApnsLiveActivtyPayload receipentToken apnsReq apnsReqTimeStamp mbStaleDate =
   let apnsReqToken = apnsReq.liveActivityToken
       apnsReqLiveActivity = apnsReq.liveActivityReqType
       apnsContentState = apnsReq.liveActivityContentState
@@ -416,6 +418,7 @@ createApnsLiveActivtyPayload receipentToken apnsReq apnsReqTimeStamp =
                             { aps =
                                 Aps
                                   { timestamp = apnsReqTimeStamp,
+                                    stale_date = mbStaleDate,
                                     content_available = 1,
                                     event = apnsReqLiveActivity,
                                     content_state = apnsContentState,

--- a/lib/mobility-core/src/Kernel/External/Notification/FCM/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Notification/FCM/Types.hs
@@ -925,6 +925,7 @@ data Aps = Aps
   { timestamp :: Int,
     alert :: Maybe Alert,
     dismissal_date :: Maybe Int,
+    stale_date :: Maybe Int,
     content_available :: Int,
     event :: Text,
     content_state :: LiveActivityContentState
@@ -940,10 +941,12 @@ instance FromJSON Aps where
 jsonApsData :: Options
 jsonApsData =
   defaultOptions
-    { fieldLabelModifier = \case
+    { omitNothingFields = True,
+      fieldLabelModifier = \case
         "content_available" -> "content-available"
         "content_state" -> "content-state"
         "dismissal_date" -> "dismissal-date"
+        "stale_date" -> "stale-date"
         other -> other
     }
 

--- a/lib/mobility-core/src/Kernel/External/Notification/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/Notification/Interface.hs
@@ -18,7 +18,8 @@ module Kernel.External.Notification.Interface
 where
 
 import EulerHS.Prelude
-import Kernel.External.Notification.FCM.Types (LiveActivityReq)
+import qualified Kernel.External.Notification.FCM.Flow as FCMFlow
+import Kernel.External.Notification.FCM.Types (FCMNotificationRecipient (..), FCMRecipientToken (..), LiveActivityReq)
 import qualified Kernel.External.Notification.Interface.FCM as FCM
 import qualified Kernel.External.Notification.Interface.GRPC as GRPC
 import qualified Kernel.External.Notification.Interface.PayTM as PayTM
@@ -54,6 +55,26 @@ notifyPerson serviceConfig req liveAcitvityRequest action = do
     FCMConfig cfg -> FCM.notifyPerson cfg req liveAcitvityRequest action (Just notificationId) EulerHS.Prelude.id
     PayTMConfig cfg -> PayTM.notifyPerson cfg req
     GRPCConfig _ -> throwError $ InternalError "GRPC notification type not supported."
+
+triggerLiveActivity ::
+  ( MonadFlow m,
+    EncFlow m r,
+    CoreMetrics m,
+    Redis.HedisFlow m r,
+    HasRequestId r,
+    MonadReader r m
+  ) =>
+  NotificationServiceConfig ->
+  Text ->
+  Maybe Text ->
+  LiveActivityReq ->
+  -- | APNs @stale-date@; when set, the sender controls when the activity goes stale.
+  Maybe Int ->
+  m ()
+triggerLiveActivity serviceConfig recipientId mbFcmToken liveActivityReq mbStaleDate =
+  case serviceConfig of
+    FCMConfig cfg -> FCMFlow.updateLiveActivity cfg (FCMNotificationRecipient recipientId (FCMRecipientToken <$> mbFcmToken)) liveActivityReq mbStaleDate
+    _ -> pure ()
 
 notifyPersonWithAllProviders ::
   ( EsqDBFlow m r,

--- a/lib/mobility-core/src/Kernel/External/Notification/Interface/FCM.hs
+++ b/lib/mobility-core/src/Kernel/External/Notification/Interface/FCM.hs
@@ -43,7 +43,7 @@ notifyPerson config req liveAcitvityRequest action mbNotificationId iosModifier 
           }
       apnsData = liveAcitvityRequest
   case apnsData of
-    (Just reqLive) -> do FCM.updateLiveActivity config (FCM.FCMNotificationRecipient req.auth.recipientId (FCM.FCMRecipientToken <$> req.auth.fcmToken)) reqLive
+    (Just reqLive) -> do FCM.updateLiveActivity config (FCM.FCMNotificationRecipient req.auth.recipientId (FCM.FCMRecipientToken <$> req.auth.fcmToken)) reqLive Nothing
     _ -> pure ()
   FCM.notifyPersonWithPriority
     config


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live Activity updates now support an optional stale date.
  * APNs payloads include the stale date when provided, helping control how long updates remain current.
  * Added notification interface support for forwarding stale-date information across supported configurations.
  * Stale-date information is omitted when it is not supplied.

* **Bug Fixes**
  * Existing Live Activity updates remain compatible when no stale date is supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->