### PR TITLE
feat: add addressComponents field to Google Maps response types

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Maps/Google/MapsClient/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Google/MapsClient/Types.hs
@@ -300,6 +300,7 @@ data DestinationPlace = DestinationPlace
     types :: Maybe [Text],
     formattedAddress :: Maybe Text,
     postalAddress :: Maybe PostalAddress,
+    addressComponents :: Maybe [AddressRespV2],
     -- | "POINT" | "SECTION" | "BUILDING" | "GROUNDS" | "..._UNSPECIFIED".
     -- Kept as 'Text' (not the 'StructureType' enum) so an unknown/new value
     -- from Google does not fail the whole response decode.


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Destination information can now include detailed address components when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->