### PR TITLE
fix: make AddressRespV2 fields optional

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Maps/Google/MapsClient/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Google/MapsClient/Types.hs
@@ -129,9 +129,9 @@ data GetPlaceDetailsRespV2 = GetPlaceDetailsRespV2
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 data AddressRespV2 = AddressRespV2
-  { longText :: Text,
-    shortText :: Text,
-    types :: [Text]
+  { longText :: Maybe Text,
+    shortText :: Maybe Text,
+    types :: Maybe [Text]
   }
   deriving stock (Generic, Show, Read)
   deriving anyclass (ToJSON, FromJSON, ToSchema)

--- a/lib/mobility-core/src/Kernel/External/Maps/Interface/Google.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Interface/Google.hs
@@ -646,9 +646,9 @@ getPlaceDetailsNew entityId cfg GetPlaceDetailsReq {..} = do
   where
     reformateAddressRespV2 aResp =
       AddressResp
-        { longName = aResp.longText,
-          shortName = aResp.shortText,
-          types = aResp.types
+        { longName = fromMaybe "" aResp.longText,
+          shortName = fromMaybe "" aResp.shortText,
+          types = fromMaybe [] aResp.types
         }
 
 getPlaceName ::


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete address data from Google Maps.
  * Missing address text now displays as blank, and missing address types are treated as empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->