### PR TITLE
Handle Google Maps old Place Details error responses without decode failure

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Maps/Google/MapsClient.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Google/MapsClient.hs
@@ -512,4 +512,5 @@ validateResponseStatus response =
     "OK" -> pure response
     "ZERO_RESULTS" -> pure response
     "INVALID_REQUEST" -> throwError GoogleMapsInvalidRequest
+    "NOT_FOUND" -> throwError GoogleMapsInvalidRequest
     _ -> throwError $ GoogleMapsCallError response.status

--- a/lib/mobility-core/src/Kernel/External/Maps/Google/MapsClient/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Google/MapsClient/Types.hs
@@ -71,7 +71,7 @@ newtype PlaceText = PlaceText
 
 data GetPlaceDetailsResp = GetPlaceDetailsResp
   { status :: Text,
-    result :: PlaceDetailsResult
+    result :: Maybe PlaceDetailsResult
   }
   deriving (Generic, ToJSON, FromJSON, ToSchema)
 

--- a/lib/mobility-core/src/Kernel/External/Maps/Interface/Google.hs
+++ b/lib/mobility-core/src/Kernel/External/Maps/Interface/Google.hs
@@ -611,8 +611,10 @@ getPlaceDetails entityId cfg req@GetPlaceDetailsReq {..} = do
       key <- decrypt cfg.googleKey
       let fields = "geometry,formatted_address,address_components,place_id"
       res <- GoogleMaps.getPlaceDetails entityId req mapsUrl key sessionToken placeId fields
-      let result = res.result
-          location = let loc = result.geometry.location in LatLong loc.lat loc.lng
+      result <- case res.result of
+        Just r -> pure r
+        Nothing -> throwError GoogleMapsInvalidRequest
+      let location = let loc = result.geometry.location in LatLong loc.lat loc.lng
           addressComponents = maybe [] (map reformateAddressResp) result.address_components
       return $ GetPlaceDetailsResp {location = location, formattedAddress = result.formatted_address, addressComponents = addressComponents, placeId = result.place_id}
     reformateAddressResp aResp =


### PR DESCRIPTION
## 🤖 Argus proposed fix

**Fix confidence:** HIGH (score 0.85)
**Reasons:** RCA high-confidence, exact line identified, confirmed pattern matched, localized diff (3f/9l)

### Root cause
The old Google Maps Place Details client decoded the response into GetPlaceDetailsResp which required a 'result' field. Google returns HTTP 200 error bodies (e.g. status=INVALID_REQUEST/NOT_FOUND) without that field, causing a DecodeFailure that the BAP app surfaced as HTTP 500. Making 'result' Maybe and adding NOT_FOUND to validateResponseStatus lets the existing status checker throw GoogleMapsInvalidRequest before the caller sees a malformed response.

### Evidence
_see RCA_

### Rollback
Revert the commit in shared-kernel and bump the backend dependency back to the previous shared-kernel version.

---
_Draft PR — review and merge manually. Generated by Argus._