### PR TITLE
backendfix: Added log on withWaitOnLockRedisWithExpiry when lock fails

### DIFF
--- a/lib/mobility-core/src/Kernel/Storage/Hedis/Queries.hs
+++ b/lib/mobility-core/src/Kernel/Storage/Hedis/Queries.hs
@@ -866,10 +866,11 @@ withWaitOnLockRedisWithExpiry key timeout recursionTimeOut func = do
 withWaitOnLockRedisWithExpiry' :: (HedisFlow m env, TryException m, MonadMask m) => Text -> Text -> ExpirationTime -> m () -> m ()
 withWaitOnLockRedisWithExpiry' recursionTimedOutKey key timeout func = do
   toExecute <- getLock recursionTimedOutKey
-  when toExecute $ do
-    finally func $ do
+  if toExecute
+    then finally func $ do
       unlockRedis key
       del recursionTimedOutKey
+    else logError $ "withWaitOnLockRedisWithExpiry: lock wait expired, action SKIPPED for key: " <> key
   where
     getLock recurrsionTimedOutKey' = do
       get recurrsionTimedOutKey' >>= \case


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [X ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error logging when a Redis lock wait expires and the associated action is skipped.
  * Preserved existing behavior when the lock is acquired successfully, including action execution and lock cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->