### PR TITLE
refactor: remove unused withLockRedis helpers from Hedis Queries

### DIFF
--- a/lib/mobility-core/src/Kernel/Storage/Hedis/Queries.hs
+++ b/lib/mobility-core/src/Kernel/Storage/Hedis/Queries.hs
@@ -27,7 +27,6 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import Data.String.Conversions
 import Data.Text hiding (any, chunksOf, concat, concatMap, length, map, null, replicate, zip)
-import qualified Data.Text as T
 import qualified Data.Text as Text
 import qualified Data.Vector as V
 import Database.Redis (keyToSlot)
@@ -57,7 +56,6 @@ import Kernel.Types.Common
 import Kernel.Utils.DatastoreLatencyCalculator
 import qualified Kernel.Utils.Error.Throwing as Error
 import Kernel.Utils.Logging
-import qualified Test.RandomStrings as RS
 
 type ExpirationTime = Int
 
@@ -882,49 +880,6 @@ withWaitAndLockMasterCloudCrossAppRedis key timeout delay func = do
       lockAvailable <- tryLockRedis key timeout
       threadDelay delay
       unless lockAvailable getLock
-
-withLockRedis :: (HedisFlow m env, TryException m, MonadMask m) => Text -> ExpirationTime -> m () -> m ()
-withLockRedis key timeout func = do
-  getLock
-  finally func (unlockRedis key)
-  where
-    getLock = do
-      lockAvailable <- tryLockRedis key timeout
-      unless lockAvailable getLock
-
-withLockRedisAndReturnValue :: (HedisFlow m env, TryException m, MonadMask m) => Text -> ExpirationTime -> m a -> m a
-withLockRedisAndReturnValue key timeout func = do
-  getLock
-  finally func (unlockRedis key)
-  where
-    getLock = do
-      lockAvailable <- tryLockRedis key timeout
-      unless lockAvailable getLock
-
-withWaitOnLockRedisWithExpiry :: (HedisFlow m env, TryException m, MonadMask m) => Text -> ExpirationTime -> ExpirationTime -> m () -> m ()
-withWaitOnLockRedisWithExpiry key timeout recursionTimeOut func = do
-  uuid <- T.pack <$> liftIO (RS.randomString (RS.onlyAlphaNum RS.randomASCII) 10)
-  let keyE = "recursion timeout for:" <> uuid
-  setExp keyE True recursionTimeOut
-  withMasterRedis $ withWaitOnLockRedisWithExpiry' keyE key timeout func
-
-withWaitOnLockRedisWithExpiry' :: (HedisFlow m env, TryException m, MonadMask m) => Text -> Text -> ExpirationTime -> m () -> m ()
-withWaitOnLockRedisWithExpiry' recursionTimedOutKey key timeout func = do
-  toExecute <- getLock recursionTimedOutKey
-  when toExecute $ do
-    finally func $ do
-      unlockRedis key
-      del recursionTimedOutKey
-  where
-    getLock recurrsionTimedOutKey' = do
-      get recurrsionTimedOutKey' >>= \case
-        Just a -> do
-          lockAvailable <- tryLockRedis key timeout
-          if not lockAvailable && a
-            then getLock recurrsionTimedOutKey'
-            else return True
-        Nothing -> do
-          tryLockRedis key timeout
 
 buildLockResourceName :: (IsString a) => Text -> a
 buildLockResourceName key = fromString $ "mobility:locker:" <> Text.unpack key


### PR DESCRIPTION
Remove withLockRedis, withLockRedisAndReturnValue, withWaitOnLockRedisWithExpiry, and its helper withWaitOnLockRedisWithExpiry' now that all call sites have been migrated. Also drop the now-unused Data.Text (T) and Test.RandomStrings (RS) imports.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed**
  * Removed four unused Redis lock helper operations from the public interface.
  * Existing Redis locking and unlocking behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->