### PR TITLE
[chore]: Adding category label for apis for metrics classification

### DIFF
--- a/lib/mobility-core/mobility-core.cabal
+++ b/lib/mobility-core/mobility-core.cabal
@@ -541,6 +541,7 @@ library
       Kernel.Tools.ARTUtils
       Kernel.Tools.Logging
       Kernel.Tools.LoopGracefully
+      Kernel.Tools.Metrics.ApiCategory
       Kernel.Tools.Metrics.AppMetrics
       Kernel.Tools.Metrics.CoreMetrics
       Kernel.Tools.Metrics.CoreMetrics.Types

--- a/lib/mobility-core/src/Kernel/Tools/Metrics/ApiCategory.hs
+++ b/lib/mobility-core/src/Kernel/Tools/Metrics/ApiCategory.hs
@@ -1,0 +1,41 @@
+module Kernel.Tools.Metrics.ApiCategory
+  ( ApiCategory (..),
+    ApiCategoryConfig (..),
+    mkApiCategoryConfig,
+    categorizeHandler,
+    apiCategoryToText,
+  )
+where
+
+import Data.Set (Set)
+import qualified Data.Set as Set
+import EulerHS.Prelude
+
+data ApiCategory
+  = Transactional
+  | Config
+  | Unclassified
+  deriving (Show, Eq, Ord)
+
+apiCategoryToText :: ApiCategory -> Text
+apiCategoryToText Transactional = "transactional"
+apiCategoryToText Config = "config"
+apiCategoryToText Unclassified = "unclassified"
+
+data ApiCategoryConfig = ApiCategoryConfig
+  { transactionalRoutes :: Set Text,
+    configRoutes :: Set Text
+  }
+
+mkApiCategoryConfig :: [Text] -> [Text] -> ApiCategoryConfig
+mkApiCategoryConfig transactionalApiRoutes configApiRoutes =
+  ApiCategoryConfig
+    { transactionalRoutes = Set.fromList transactionalApiRoutes,
+      configRoutes = Set.fromList configApiRoutes
+    }
+
+categorizeHandler :: ApiCategoryConfig -> Text -> ApiCategory
+categorizeHandler cfg route
+  | route `Set.member` transactionalRoutes cfg = Transactional
+  | route `Set.member` configRoutes cfg = Config
+  | otherwise = Unclassified

--- a/lib/mobility-core/src/Kernel/Tools/Metrics/Init.hs
+++ b/lib/mobility-core/src/Kernel/Tools/Metrics/Init.hs
@@ -24,6 +24,7 @@ import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8)
 import EulerHS.Prelude as E hiding (decodeUtf8)
 import Kernel.Prelude (lookup, (!!))
+import Kernel.Tools.Metrics.ApiCategory
 import Kernel.Tools.Metrics.CoreMetrics.Types hiding (requestLatency)
 import Kernel.Utils.Monitoring.Prometheus.Servant
 import qualified Network.HTTP.Types as HTTP
@@ -50,10 +51,10 @@ requestLatency =
         "The HTTP request latencies in seconds."
 
 {-# NOINLINE requestLatencyWithVersionLabel #-}
-requestLatencyWithVersionLabel :: Prom.Vector Prom.Label6 Prom.Histogram
+requestLatencyWithVersionLabel :: Prom.Vector Prom.Label7 Prom.Histogram
 requestLatencyWithVersionLabel =
   Prom.unsafeRegister $
-    Prom.vector ("handler", "method", "status_code", "version", "x_client_version", "x_bundle_version") $
+    Prom.vector ("handler", "method", "status_code", "version", "x_client_version", "x_bundle_version", "category") $
       Prom.histogram info Prom.defaultBuckets
   where
     info =
@@ -72,30 +73,33 @@ serve port = do
 addServantInfo ::
   SanitizedUrl a =>
   DeploymentVersion ->
+  ApiCategoryConfig ->
   Proxy a ->
   Application ->
   Application
-addServantInfo version proxy app request respond =
+addServantInfo version apiCategoryConfig proxy app request respond =
   let mpath = getSanitizedUrl proxy (Just request)
       fullpath = DT.intercalate "/" (normalizedPathInfo request)
-   in instrumentHandlerValueWithVersionLabel version.getDeploymentVersion (\_ -> "/" <> fromMaybe fullpath mpath) app request respond
+   in instrumentHandlerValueWithVersionLabel version.getDeploymentVersion apiCategoryConfig (\_ -> "/" <> fromMaybe fullpath mpath) app request respond
 
 instrumentHandlerValueWithVersionLabel ::
   -- | version label
   Text ->
+  ApiCategoryConfig ->
   -- | The function used to derive the "handler" value in Prometheus
   (Wai.Request -> Text) ->
   -- | The app to instrument
   Wai.Application ->
   -- | The instrumented app
   Wai.Application
-instrumentHandlerValueWithVersionLabel versionLabel = instrumentHandlerValueWithFilter (Just versionLabel) Just
+instrumentHandlerValueWithVersionLabel versionLabel apiCategoryConfig = instrumentHandlerValueWithFilter (Just versionLabel) apiCategoryConfig Just
 
 -- | A more flexible variant of 'instrumentHandlerValue'.  The filter can change some
 -- responses, or drop others entirely.
 instrumentHandlerValueWithFilter ::
   -- | version label
   Maybe Text ->
+  ApiCategoryConfig ->
   -- | Response filter
   (Wai.Response -> Maybe Wai.Response) ->
   -- | The function used to derive the "handler" value in Prometheus
@@ -104,7 +108,7 @@ instrumentHandlerValueWithFilter ::
   Wai.Application ->
   -- | The instrumented app
   Wai.Application
-instrumentHandlerValueWithFilter mbVersionLabel resFilter f app req respond = do
+instrumentHandlerValueWithFilter mbVersionLabel apiCategoryConfig resFilter f app req respond = do
   start <- getTime Monotonic
   app req $ \res -> do
     case resFilter res of
@@ -114,7 +118,9 @@ instrumentHandlerValueWithFilter mbVersionLabel resFilter f app req respond = do
         let method = Just $ decodeUtf8 (Wai.requestMethod req)
         let status = Just $ T.pack (show (HTTP.statusCode (Wai.responseStatus res')))
         let requiredHeaders = map (T.pack . show <$>) (flip lookup (Wai.requestHeaders req) . stringToCI <$> ["x-client-version", "x-bundle-version"])
-        observeSeconds mbVersionLabel (f req) method status start end requiredHeaders
+        let route = f req
+        let category = categorizeHandler apiCategoryConfig route
+        observeSeconds mbVersionLabel route method status start end requiredHeaders category
     respond res
 
 stringToCI :: String -> CI ByteString
@@ -135,8 +141,9 @@ observeSeconds ::
   TimeSpec ->
   -- | required headers
   [Maybe Text] ->
+  ApiCategory ->
   IO ()
-observeSeconds mbVersionLabel handler method status start end requiredHeaders = do
+observeSeconds mbVersionLabel handler method status start end requiredHeaders category = do
   let latency :: Double
       latency = fromRational (toNanoSecs (end `diffTimeSpec` start) % 1000000000)
   case mbVersionLabel of
@@ -148,5 +155,5 @@ observeSeconds mbVersionLabel handler method status start end requiredHeaders = 
     Just versionLabel -> do
       Prom.withLabel
         requestLatencyWithVersionLabel
-        (handler, fromMaybe "" method, fromMaybe "" status, versionLabel, fromMaybe "" (requiredHeaders !! 0), fromMaybe "" (requiredHeaders !! 1))
+        (handler, fromMaybe "" method, fromMaybe "" status, versionLabel, fromMaybe "" (requiredHeaders !! 0), fromMaybe "" (requiredHeaders !! 1), apiCategoryToText category)
         (flip Prom.observe latency)

--- a/lib/mobility-core/src/Kernel/Utils/Servant/Server.hs
+++ b/lib/mobility-core/src/Kernel/Utils/Servant/Server.hs
@@ -24,6 +24,7 @@ import GHC.Records.Extra (HasField)
 import Kernel.Prelude (identity)
 import Kernel.Storage.Esqueleto.Config (EsqDBEnv (..))
 import Kernel.Storage.Hedis.Config (HedisEnv (..))
+import qualified Kernel.Tools.Metrics.ApiCategory as Metrics
 import qualified Kernel.Tools.Metrics.CoreMetrics.Types as Metrics
 import qualified Kernel.Tools.Metrics.Init as Metrics
 import Kernel.Tools.Slack.Internal
@@ -145,7 +146,7 @@ runServer appEnv serverAPI serverHandler waiMiddleware waiSettings servantCtx se
   let server = withModifiedEnv $ \modifiedEnv ->
         run serverAPI serverHandler servantCtx modifiedEnv
           & logRequestAndResponse modifiedEnv
-          & Metrics.addServantInfo appEnv.version serverAPI
+          & Metrics.addServantInfo appEnv.version (Metrics.mkApiCategoryConfig [] []) serverAPI
           & waiMiddleware
   E.withFlowRuntime (Just loggerRt) $ \flowRt -> do
     flowRt' <-
@@ -190,7 +191,7 @@ runServerGeneric appEnv serverAPI serverHandler waiMiddleware waiSettings servan
         let loggerFunc = \tag info -> logOutputIO (appendLogTag tag $ modifiedEnv.loggerEnv) INFO info modifiedEnv.requestId modifiedEnv.sessionId
          in runGeneric serverAPI serverHandler servantCtx modifiedEnv runMonad
               & logRequestAndResponseGeneric loggerFunc
-              & Metrics.addServantInfo appEnv.version serverAPI
+              & Metrics.addServantInfo appEnv.version (Metrics.mkApiCategoryConfig [] []) serverAPI
               & waiMiddleware
   serverStartAction appEnv $ runSettings settings $ server appEnv
 


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Prometheus request-latency metrics now include an API category label.
  - API requests can be classified as transactional, configuration-related, or unclassified.
  - Route-based category configuration is supported, with transactional routes taking precedence when overlaps occur.
  - Existing server setups continue to work with default category configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->