### PR TITLE
backend/chore: bump euler-hs to pick up the fork/await polling fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -387,11 +387,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787042391,
-        "narHash": "sha256-jzw8rcK4ko89AY8agtZrg9gKXrgN+jrr+AKsgOS52jE=",
+        "lastModified": 1788879727,
+        "narHash": "sha256-E2tLidBZan1jsDrX+kMu6VDN9HZBN+ojSBiBxE35Wqs=",
         "owner": "nammayatri",
         "repo": "euler-hs",
-        "rev": "6290a7e3bad44e786621f016fa1991ecb48b9802",
+        "rev": "7e233136bafcb5110a568a06c6c3498ae3bbee1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Bumps the `euler-hs` input in `flake.lock`:

```
6290a7e3bad44e786621f016fa1991ecb48b9802  (2026-08-18)
  →  7e233136bafcb5110a568a06c6c3498ae3bbee1f  (2026-09-08)
```

`7e23313` is the squash merge of [nammayatri/euler-hs#75](https://github.com/nammayatri/euler-hs/pull/75) and is current `euler-hs` `main`. `main` is exactly **one commit ahead** of the old pin, so this brings in that change and nothing else. Only the `euler-hs` node in `flake.lock` moves — no other input is re-locked.

## What euler-hs#75 changes

`awaitMVarWithTimeout` in `EulerHS/Framework/Interpreter.hs` stops polling the result MVar and blocks on it instead:

```haskell
awaitMVarWithTimeout mvar mcs
  | mcs <= 0  = toAwaitResult <$> tryReadMVar mvar
  | otherwise = toAwaitResult <$> timeout mcs (readMVar mvar)
```

The old loop slept `portion = (mcs `div` 10) + 1` between `tryReadMVar` attempts, so the resolution of an await was one tenth of its own timeout. `timeout` is from `base`, so no new dependency. The `mcs <= 0` path and `L.await Nothing` (which never went through this function) are unchanged; every input still produces the same result value, only the wake-up time changes.

The PR also adds one regression test in `test/language/FlowSpec.hs`: a ~10 ms fork awaited with a 5 s timeout must return in under 250 ms.

## Why this matters downstream

nammayatri's rider-app calls `L.await (Just syncSearchTimeoutMicros)` with a 5 s timeout on the synchronous ride-search path, which under the old code meant a 500 ms poll grid — a hard ~500 ms floor plus a mean +250 ms on every *successful* await, independent of how fast the BPP answered.

## Testing

- `nix flake update euler-hs` produced the diff; no manual editing of `flake.lock`.
- Not yet built against this pin locally — relying on CI for the `shared-kernel` build. Given the blast radius of euler-hs, this wants UAT validation before it rides into prod via a `shared-kernel` bump in nammayatri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br3rF7fuayjDMfY5onxuZ7