### PR TITLE
fix: stripeLegalEntityName

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Payment/Interface.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface.hs
@@ -542,6 +542,12 @@ getUseDomainOffers = \case
   StripeConfig cfg -> fromMaybe False cfg.useDomainOffers
   PaytmEDCConfig _ -> False
 
+legalEntityName :: PaymentServiceConfig -> Maybe Text
+legalEntityName = \case
+  StripeConfig cfg -> cfg.legalEntityName
+  JuspayConfig _ -> Nothing
+  PaytmEDCConfig _ -> Nothing
+
 -- | Unified payment creation. Routes to Juspay createOrder or Stripe createPaymentIntent
 --   based on PaymentServiceConfig. Domain code calls this single function.
 createPayment ::

--- a/lib/mobility-core/src/Kernel/External/Payment/Stripe/Config.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Stripe/Config.hs
@@ -44,7 +44,8 @@ data StripeCfg = StripeCfg
     serviceMode :: Maybe ServiceMode,
     useDomainOffers :: Maybe Bool,
     statementDescriptor :: Maybe Text,
-    requestIncrementalAuthorization :: Maybe Text
+    requestIncrementalAuthorization :: Maybe Text,
+    legalEntityName :: Maybe Text
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Stripe payment configurations can now include an optional legal entity name.
  - The configured legal entity name can be retrieved when available.
  - Legal entity names remain unavailable for Juspay and Paytm EDC payment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->