### PR TITLE
feat: usage counter fields on payment OfferResp

### DIFF
--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Juspay.hs
@@ -999,7 +999,9 @@ mkOfferResp offer = do
         cashbackAmount = read $ T.unpack order_breakup.cashback_amount,
         benefitType = benefitType',
         offerCode = offer_code,
-        productDiscounts
+        productDiscounts,
+        minimumAmount = Nothing,
+        counters = Nothing
       }
   where
     Juspay.OfferResp {offer_id, status, offer_code, offer_description, ui_configs, order_breakup} = offer

--- a/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
+++ b/lib/mobility-core/src/Kernel/External/Payment/Interface/Types.hs
@@ -624,7 +624,17 @@ data OfferResp = OfferResp
     cashbackAmount :: HighPrecMoney,
     benefitType :: Text, -- "CASHBACK" or "DISCOUNT"
     offerCode :: Text,
-    productDiscounts :: Maybe [ProductDiscount]
+    productDiscounts :: Maybe [ProductDiscount],
+    minimumAmount :: Maybe HighPrecMoney,
+    counters :: Maybe OfferCounters
+  }
+  deriving (Generic, Show, FromJSON, ToJSON)
+  deriving anyclass (ToSchema)
+
+data OfferCounters = OfferCounters
+  { frequencyType :: Maybe Text,
+    appliedCount :: Maybe Int,
+    maxApplyCount :: Maybe Int
   }
   deriving (Generic, Show, FromJSON, ToJSON)
   deriving anyclass (ToSchema)


### PR DESCRIPTION
Optional minimumAmount and a counters object (frequencyType, appliedCount, maxApplyCount) on Interface.Types.OfferResp for domain offers; the Juspay adapter leaves both empty.

## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates

## Description
<!-- Describe your changes in detail -->


### Additional Changes

- [ ] This PR modifies the database schema (database migration added)
- [ ] This PR modifies dhall configs/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->


## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code and addressed linter errors `./dev/format-all-files.sh`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Offer responses now support additional optional details, including offer frequency, applied count, maximum application count, and minimum eligible amount.
  - Existing product discount information remains supported alongside these offer details.
  - When these values are unavailable, the response leaves them unset rather than providing inaccurate information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->