### PR TITLE
backend/feat: add forks_started_total and forks_finished_total counters

### DIFF
--- a/lib/mobility-core/src/Kernel/Mock/App.hs
+++ b/lib/mobility-core/src/Kernel/Mock/App.hs
@@ -82,6 +82,7 @@ instance CoreMetrics (MockM e) where
   addOpenTripPlannerLatency _ _ _ = return ()
   incrementTryExceptionCounter _ _ = return ()
   incrementSmsProviderResponseCounter _ _ = return ()
+  withForkCounters _ _ action = action
 
 instance MonadTime (MockM e) where
   getCurrentTime = liftIO getCurrentTime

--- a/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics.hs
+++ b/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics.hs
@@ -20,6 +20,8 @@ module Kernel.Tools.Metrics.CoreMetrics
   )
 where
 
+import qualified Control.Monad.Catch as C
+import qualified Data.Set as Set
 import Data.Text as DT
 import qualified EulerHS.Language as L
 import EulerHS.Prelude as E
@@ -602,3 +604,47 @@ incrementTryExceptionCounterImplementation' cmContainers errorContext exc versio
           tryExceptionCounterMetric
           (show $ toHttpCode err, errorContext, toErrorCode err, version.getDeploymentVersion, sanitizedUrl)
           P.incCounter
+
+withForkCountersImplementation ::
+  ( HasCoreMetrics r,
+    L.MonadFlow m,
+    MonadReader r m
+  ) =>
+  Text ->
+  Text ->
+  m a ->
+  m a
+withForkCountersImplementation tag forkType action = do
+  cmContainer <- asks (.coreMetrics)
+  version <- asks (.version)
+  tagLabel <- L.runIO $ forkTagLabel cmContainer.forkTagLabels tag
+  let increment metric = L.runIO $ P.withLabel metric (tagLabel, forkType, version.getDeploymentVersion) P.incCounter
+  C.bracket_ (increment cmContainer.forkStartedCounter) (increment cmContainer.forkFinishedCounter) action
+
+forkTagLabelLimit :: Int
+forkTagLabelLimit = 300
+
+forkTagLabelLength :: Int
+forkTagLabelLength = 32
+
+{-# NOINLINE uuidRegex #-}
+uuidRegex :: TR.Regex
+uuidRegex = TR.mkRegex "[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}"
+
+sanitizeForkTag :: Text -> Text
+sanitizeForkTag tag =
+  DT.take forkTagLabelLength $
+    if DT.length tag < 36
+      then tag
+      else DT.pack $ TR.subRegex uuidRegex (DT.unpack tag) ":id"
+
+forkTagLabel :: IORef (Set.Set Text) -> Text -> IO Text
+forkTagLabel knownLabels tag = do
+  let label = sanitizeForkTag tag
+  atomicModifyIORef' knownLabels $ \known ->
+    if Set.member label known
+      then (known, label)
+      else
+        if Set.size known < forkTagLabelLimit
+          then (Set.insert label known, label)
+          else (known, "other")

--- a/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics/Types.hs
+++ b/lib/mobility-core/src/Kernel/Tools/Metrics/CoreMetrics/Types.hs
@@ -21,6 +21,7 @@ module Kernel.Tools.Metrics.CoreMetrics.Types
   )
 where
 
+import qualified Data.Set as Set
 import qualified EulerHS.KVConnector.Metrics as KVMetrics
 import EulerHS.Prelude as E
 import GHC.Records.Extra
@@ -92,6 +93,8 @@ type OpenTripPlannerLatencyMetric = P.Vector P.Label3 P.Histogram
 -- | Per-provider SMS outcome counter (labels: "provider", "status", "version").
 type SmsProviderResponseMetric = P.Vector P.Label3 P.Counter
 
+type ForkCounterMetric = P.Vector P.Label3 P.Counter
+
 newBuckets :: [Double]
 newBuckets = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 20, 25, 30, 40, 50]
 
@@ -141,6 +144,7 @@ class CoreMetrics m where
   setRedisStreamLength :: Int -> Integer -> m ()
   setRedisStreamPending :: Int -> Integer -> m ()
   incrementSmsProviderResponseCounter :: Text -> Text -> m ()
+  withForkCounters :: Text -> Text -> m a -> m a
 
 data CoreMetricsContainer = CoreMetricsContainer
   { requestLatency :: RequestLatencyMetric,
@@ -172,7 +176,10 @@ data CoreMetricsContainer = CoreMetricsContainer
     genericLatencyMetrics :: GenericLatencyMetric,
     openTripPlannerResponseMetric :: OpenTripPlannerResponseMetric,
     openTripPlannerLatencyMetric :: OpenTripPlannerLatencyMetric,
-    smsProviderResponseCounter :: SmsProviderResponseMetric
+    smsProviderResponseCounter :: SmsProviderResponseMetric,
+    forkStartedCounter :: ForkCounterMetric,
+    forkFinishedCounter :: ForkCounterMetric,
+    forkTagLabels :: IORef (Set.Set Text)
   }
 
 registerCoreMetricsContainer :: IO CoreMetricsContainer
@@ -207,6 +214,9 @@ registerCoreMetricsContainer = do
   openTripPlannerResponseMetric <- registerOpenTripPlannerResponseMetric
   openTripPlannerLatencyMetric <- registerOpenTripPlannerLatencyMetric
   smsProviderResponseCounter <- registerSmsProviderResponseMetric
+  forkStartedCounter <- registerForkCounter "forks_started_total" "Forked threads started, labelled by sanitized fork tag, fork type and version"
+  forkFinishedCounter <- registerForkCounter "forks_finished_total" "Forked threads finished (success, error or killed), labelled by sanitized fork tag, fork type and version"
+  forkTagLabels <- newIORef Set.empty
   return CoreMetricsContainer {..}
 
 registerDatastoresLatencyMetrics :: IO DatastoresLatencyMetric
@@ -438,3 +448,9 @@ registerSmsProviderResponseMetric =
       P.counter info
   where
     info = P.Info "sms_provider_response_counter" "SMS provider outcome counter labelled by provider, status (success/failure) and version"
+
+registerForkCounter :: Text -> Text -> IO ForkCounterMetric
+registerForkCounter name help =
+  P.register $
+    P.vector ("tag", "fork_type", "version") $
+      P.counter (P.Info name help)

--- a/lib/mobility-core/src/Kernel/Types/Flow.hs
+++ b/lib/mobility-core/src/Kernel/Types/Flow.hs
@@ -247,6 +247,7 @@ instance Metrics.HasCoreMetrics r => Metrics.CoreMetrics (FlowR r) where
   addOpenTripPlannerLatency = Metrics.addOpenTripPlannerLatencyImplementation
   incrementTryExceptionCounter = Metrics.incrementTryExceptionCounterImplementation
   incrementSmsProviderResponseCounter = Metrics.incrementSmsProviderResponseCounterImplementation
+  withForkCounters = Metrics.withForkCountersImplementation
 
 instance MonadMonitor (FlowR r) where
   doIO = liftIO
@@ -259,17 +260,17 @@ instance (Log (FlowR r), Metrics.CoreMetrics (FlowR r), HasARTFlow r) => Forkabl
     seedLocalOptions <- carryForkLocalOptions
     newLocalOptions <- newMVar mempty
     -- logRequestIdForFork tag
-    FlowR $ ReaderT $ L.forkFlow tag . L.withModifiedRuntime (refreshLocalOptions newLocalOptions) . runReaderT (unFlowR $ seedLocalOptions >> handleForkExecution tag f)
+    FlowR $ ReaderT $ L.forkFlow tag . L.withModifiedRuntime (refreshLocalOptions newLocalOptions) . runReaderT (unFlowR $ Metrics.withForkCounters tag "fork" (seedLocalOptions >> handleForkExecution tag f))
 
   forkMultiple tagAndFunction = do
     seedLocalOptions <- carryForkLocalOptions
     newLocalOptions <- newMVar mempty
-    FlowR $ ReaderT $ L.forkFlow "multiple-Forks" . L.withModifiedRuntime (refreshLocalOptions newLocalOptions) . runReaderT (unFlowR $ seedLocalOptions >> handleForkExecutionMultiple tagAndFunction)
+    FlowR $ ReaderT $ L.forkFlow "multiple-Forks" . L.withModifiedRuntime (refreshLocalOptions newLocalOptions) . runReaderT (unFlowR $ Metrics.withForkCounters "multiple-Forks" "fork_multiple" (seedLocalOptions >> handleForkExecutionMultiple tagAndFunction))
 
   awaitableFork tag f = do
     seedLocalOptions <- carryForkLocalOptions
     newLocalOptions <- newMVar mempty
-    FlowR $ ReaderT $ L.forkFlow' tag . L.withModifiedRuntime (refreshLocalOptions newLocalOptions) . runReaderT (unFlowR $ seedLocalOptions >> handleExc f)
+    FlowR $ ReaderT $ L.forkFlow' tag . L.withModifiedRuntime (refreshLocalOptions newLocalOptions) . runReaderT (unFlowR $ Metrics.withForkCounters tag "awaitable_fork" (seedLocalOptions >> handleExc f))
     where
       handleExc f' = do
         res <- try f'

--- a/lib/mobility-core/test/src/APIExceptions.hs
+++ b/lib/mobility-core/test/src/APIExceptions.hs
@@ -82,6 +82,7 @@ instance Metrics.CoreMetrics IO where
   incrementTryExceptionCounter _ _ = return ()
   incrementProducerError _ = return ()
   incrementSmsProviderResponseCounter _ _ = return ()
+  withForkCounters _ _ action = action
 
 httpExceptionTests :: TestTree
 httpExceptionTests =


### PR DESCRIPTION
## What

Adds two Prometheus counters that track forked threads created through `Forkable (FlowR r)` (`fork`, `awaitableFork`, `forkMultiple`):

| Metric | Type | Labels |
|---|---|---|
| `forks_started_total` | Counter | `tag`, `fork_type`, `version` |
| `forks_finished_total` | Counter | `tag`, `fork_type`, `version` |

`fork_type` ∈ `fork` / `awaitable_fork` / `fork_multiple`. The `pod` label is added by vmagent at scrape time.

Active forks per pod at any instant:

```promql
sum by (pod) (forks_started_total{service="beckn-driver-offer-bpp-production"})
  - sum by (pod) (forks_finished_total{service="beckn-driver-offer-bpp-production"})
```

Which fork is piling up:

```promql
topk(10, sum by (tag) (forks_started_total - forks_finished_total))
```

## How

- New `CoreMetrics` method `withForkCounters :: Text -> Text -> m a -> m a`. The `FlowR` implementation wraps the forked body in `bracket_`, so `forks_finished_total` increments on success, on error, and when the thread is killed by an async exception. euler-hs's `GeneralBracket` interprets to the real IO `generalBracket`.
- Counting happens inside the forked thread, so it reflects threads that are actually running, and the tag sanitisation cost stays off the caller's thread.
- `MockM` and the test `IO` instance are no-ops. There are no `CoreMetrics` instances in nammayatri, so consumers only need a flake bump.

## Tag label cardinality

47 call sites append ids to the fork tag, e.g. `"cancelBooking:" <> bookingId`. Prod logs confirm values like `cancelBooking:0baf1774-afb8-…`. To keep the label bounded, the tag is sanitised before use:

1. UUIDs are replaced with `:id` (for tags of 36+ chars; the regex is compiled once).
2. The result is truncated to 32 chars.
3. At most 300 distinct tag labels per process; anything beyond is recorded as `other`.

Worst case this adds 600 series per pod (~1% on driver-bpp, ~3% on rider-app at today's per-pod series counts).

The forks-started and forks-finished counters for the same raw tag always resolve to the same label, because sanitisation is deterministic and the known-label set only grows.

## Testing

- `cabal build mobility-core:lib:mobility-core` passes; `cabal test mobility-core:tests` passes.
- Formatted with the repo's treefmt ormolu settings (check mode clean). hlint reports no new hints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyZ8n4mSmpcmEnPfX7GVb5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added lifecycle metrics for background fork operations, including started and completed counts.
  - Fork metrics now distinguish standard, multiple, and awaitable fork operations.
  - Added fork labels to help identify activity by operation and deployment version.
  - Labels are normalized to remove volatile identifiers, limited in length, and grouped under “other” when too many unique values are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->